### PR TITLE
[WIP] Cache elements found by the locator via 'cacheLookup' annotation

### DIFF
--- a/library/QATools/QATools/PageObject/Annotation/FindByAnnotation.php
+++ b/library/QATools/QATools/PageObject/Annotation/FindByAnnotation.php
@@ -98,6 +98,13 @@ class FindByAnnotation extends Annotation
 	public $using;
 
 	/**
+	 * Whatever or not found elements, found by IElementLocator should be internally cached.
+	 *
+	 * @var boolean
+	 */
+	public $cache = false;
+
+	/**
 	 * Returns a selector, created based on annotation parameters.
 	 *
 	 * @return array

--- a/library/QATools/QATools/PageObject/ElementLocator/DefaultElementLocator.php
+++ b/library/QATools/QATools/PageObject/ElementLocator/DefaultElementLocator.php
@@ -48,6 +48,20 @@ class DefaultElementLocator implements IElementLocator
 	protected $property;
 
 	/**
+	 * Cache found elements locally.
+	 *
+	 * @var boolean
+	 */
+	protected $shouldCache = false;
+
+	/**
+	 * Cached NodeElement list.
+	 *
+	 * @var NodeElement[]
+	 */
+	protected $cachedElements;
+
+	/**
 	 * Creates a new element locator.
 	 *
 	 * @param Property          $property           Property.
@@ -90,10 +104,18 @@ class DefaultElementLocator implements IElementLocator
 	 */
 	public function findAll()
 	{
+		if ( isset($this->cachedElements) && $this->shouldCache ) {
+			return $this->cachedElements;
+		}
+
 		$elements = array();
 
 		foreach ( $this->getSelectors() as $selector ) {
 			$elements = array_merge($elements, $this->searchContext->findAll('se', $selector));
+		}
+
+		if ( $this->shouldCache ) {
+			$this->cachedElements = $elements;
 		}
 
 		return $elements;


### PR DESCRIPTION
In the Java version of Selenium there was a `@cacheLookup` annotation that allowed to cache found `WebElement` class objects right inside of the `ElementLocator` class that searched for them.

If ElementLocator is to be used as a standalone component, then it might make sense, but the `PageFactory` is creating a separate locator class per each Page/ElementContainer class property it decorates and only accesses it once when element is being used, so caching doesn't really make sense.

We might implement the caching if somebody will be using ElementLocator in custom factory to save on calls made to the browser for element location. This cache however might result in stale element returning, that is no longer present in DOM.
