### PR TITLE
Update Mink version detecting code

### DIFF
--- a/library/aik099/QATools/HtmlElements/Element/Form.php
+++ b/library/aik099/QATools/HtmlElements/Element/Form.php
@@ -58,13 +58,7 @@ class Form extends ElementContainer
 	 */
 	public function getWebElement($field_name)
 	{
-		if ( $this->_isAutomaticSelectorEscaping() ) {
-			$node_element = $this->find('named', array('field', $field_name));
-		}
-		else {
-			$escaped_field_name = $this->getSelectorsHandler()->xpathLiteral($field_name);
-			$node_element = $this->find('named', array('field', $escaped_field_name));
-		}
+		$node_element = $this->find('named', array('field', $this->_autoEscapeForXpath($field_name)));
 
 		if ( is_null($node_element) ) {
 			throw new FormException(
@@ -79,11 +73,20 @@ class Form extends ElementContainer
 	/**
 	 * Determines if Mink does automatic selector escaping.
 	 *
-	 * @return boolean
+	 * @param string $string Text to escape.
+	 *
+	 * @return string
 	 */
-	private function _isAutomaticSelectorEscaping()
+	private function _autoEscapeForXpath($string)
 	{
-		return class_exists('Behat\\Mink\\Selector\\Xpath\\Escaper');
+		$selectors_handler = $this->getSelectorsHandler();
+
+		// Needed for Mink 1.5 and below.
+		if ( method_exists($selectors_handler, 'xpathLiteral') ) {
+			return $selectors_handler->xpathLiteral($string);
+		}
+
+		return $string;
 	}
 
 	/**

--- a/tests/aik099/QATools/HtmlElements/Element/FormTest.php
+++ b/tests/aik099/QATools/HtmlElements/Element/FormTest.php
@@ -69,12 +69,12 @@ class FormTest extends ElementContainerTest
 	 */
 	public function testGetWebElementFailure()
 	{
-		if ( $this->_isAutomaticSelectorEscaping() ) {
-			$this->webElement->shouldReceive('find')->with('named', array('field', 'field-name'))->once()->andReturnNull();
-		}
-		else {
+		if ( method_exists($this->selectorsHandler, 'xpathLiteral') ) {
 			$this->selectorsHandler->shouldReceive('xpathLiteral')->with('field-name')->once()->andReturn("'field-name'");
 			$this->webElement->shouldReceive('find')->with('named', array('field', "'field-name'"))->once()->andReturnNull();
+		}
+		else {
+			$this->webElement->shouldReceive('find')->with('named', array('field', 'field-name'))->once()->andReturnNull();
 		}
 
 		$this->getElement()->getWebElement('field-name');
@@ -89,18 +89,18 @@ class FormTest extends ElementContainerTest
 	{
 		$node_element = $this->createNodeElement();
 
-		if ( $this->_isAutomaticSelectorEscaping() ) {
-			$this->webElement
-				->shouldReceive('find')
-				->with('named', array('field', 'field-name'))
-				->once()
-				->andReturn($node_element);
-		}
-		else {
+		if ( method_exists($this->selectorsHandler, 'xpathLiteral') ) {
 			$this->selectorsHandler->shouldReceive('xpathLiteral')->with('field-name')->once()->andReturn("'field-name'");
 			$this->webElement
 				->shouldReceive('find')
 				->with('named', array('field', "'field-name'"))
+				->once()
+				->andReturn($node_element);
+		}
+		else {
+			$this->webElement
+				->shouldReceive('find')
+				->with('named', array('field', 'field-name'))
 				->once()
 				->andReturn($node_element);
 		}
@@ -109,16 +109,6 @@ class FormTest extends ElementContainerTest
 
 		$this->assertInstanceOf(self::WEB_ELEMENT_CLASS, $found_element);
 		$this->assertEquals('XPATH', $found_element->getXpath());
-	}
-
-	/**
-	 * Determines if Mink does automatic selector escaping.
-	 *
-	 * @return boolean
-	 */
-	private function _isAutomaticSelectorEscaping()
-	{
-		return class_exists('Behat\\Mink\\Selector\\Xpath\\Escaper');
 	}
 
 	/**

--- a/tests/aik099/QATools/TestCase.php
+++ b/tests/aik099/QATools/TestCase.php
@@ -55,6 +55,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
 
 		$this->session = m::mock('\\Behat\\Mink\\Session');
 		$this->session->shouldReceive('getSelectorsHandler')->andReturn($this->selectorsHandler);
+		$this->session->shouldReceive('getDriver')->byDefault();
 
 		$this->pageFactory = m::mock('\\aik099\\QATools\\PageObject\\IPageFactory');
 		$this->pageFactory->shouldReceive('getSession')->andReturn($this->session);


### PR DESCRIPTION
After Behat/Mink#540 will be merged the escaping of field names in `Form` typified element will no longer work.

@stof proposed to check for `SelectorsHandler::xpathLiteral` method presence instead of checking for `Escaper` class presence in general.
