### PR TITLE
Support multiple @find-by annotations

### DIFF
--- a/library/QATools/QATools/BEM/Proxy/BlockProxy.php
+++ b/library/QATools/QATools/BEM/Proxy/BlockProxy.php
@@ -43,6 +43,28 @@ class BlockProxy extends AbstractPartProxy implements IBlock
 	}
 
 	/**
+	 * Locates object inside proxy.
+	 *
+	 * @return void
+	 * @throws ElementNotFoundException When block not found.
+	 */
+	protected function locateObject()
+	{
+		if ( is_object($this->object) ) {
+			return;
+		}
+
+		$nodes = $this->locator->findAll();
+
+		if ( !$nodes ) {
+			throw new ElementNotFoundException('Block not found by selector: ' . (string)$this->locator);
+		}
+
+		$this->object = new $this->className($this->getName(), $nodes, $this->pageFactory, $this->locator);
+		$this->object->setContainer($this->getContainer());
+	}
+
+	/**
 	 * Returns block instance.
 	 *
 	 * @return IBlock
@@ -50,16 +72,7 @@ class BlockProxy extends AbstractPartProxy implements IBlock
 	 */
 	public function getObject()
 	{
-		if ( !is_object($this->object) ) {
-			$nodes = $this->locator->findAll();
-
-			if ( !$nodes ) {
-				throw new ElementNotFoundException('Block not found by selector: ' . (string)$this->locator);
-			}
-
-			$this->object = new $this->className($this->getName(), $nodes, $this->pageFactory, $this->locator);
-			$this->object->setContainer($this->getContainer());
-		}
+		$this->locateObject();
 
 		return $this->object;
 	}

--- a/library/QATools/QATools/BEM/Proxy/ElementProxy.php
+++ b/library/QATools/QATools/BEM/Proxy/ElementProxy.php
@@ -42,18 +42,30 @@ class ElementProxy extends AbstractPartProxy implements IElement
 	}
 
 	/**
+	 * Locates object inside proxy.
+	 *
+	 * @return void
+	 */
+	protected function locateObject()
+	{
+		if ( is_object($this->object) ) {
+			return;
+		}
+
+		$web_element = WebElement::fromNodeElement($this->locateElement());
+
+		$this->object = new $this->className($this->getName(), $web_element);
+		$this->object->setContainer($this->getContainer());
+	}
+
+	/**
 	 * Returns element instance.
 	 *
 	 * @return IElement
 	 */
 	public function getObject()
 	{
-		if ( !is_object($this->object) ) {
-			$web_element = WebElement::fromNodeElement($this->locateElement());
-
-			$this->object = new $this->className($this->getName(), $web_element);
-			$this->object->setContainer($this->getContainer());
-		}
+		$this->locateObject();
 
 		return $this->object;
 	}

--- a/library/QATools/QATools/HtmlElements/PropertyDecorator/TypifiedPropertyDecorator.php
+++ b/library/QATools/QATools/HtmlElements/PropertyDecorator/TypifiedPropertyDecorator.php
@@ -38,6 +38,13 @@ class TypifiedPropertyDecorator extends DefaultPropertyDecorator
 	private $_typifiedElementInterface = '\\QATools\\QATools\\HtmlElements\\Element\\ITypifiedElement';
 
 	/**
+	 * Typified element collection.
+	 *
+	 * @var string
+	 */
+	private $_typifiedElementCollection = '\\QATools\\QATools\\HtmlElements\\Element\\AbstractTypifiedElementCollection';
+
+	/**
 	 * Creates decorator instance.
 	 *
 	 * @param IElementLocatorFactory $locator_factory Locator factory.
@@ -47,6 +54,7 @@ class TypifiedPropertyDecorator extends DefaultPropertyDecorator
 	{
 		parent::__construct($locator_factory, $page_factory);
 
+		$this->elementToProxyMapping[$this->_typifiedElementCollection] = '\\QATools\\QATools\\HtmlElements\\Proxy\\TypifiedElementCollectionProxy';
 		$this->elementToProxyMapping[$this->_typifiedElementInterface] = '\\QATools\\QATools\\HtmlElements\\Proxy\\TypifiedElementProxy';
 	}
 

--- a/library/QATools/QATools/HtmlElements/Proxy/TypifiedElementCollectionProxy.php
+++ b/library/QATools/QATools/HtmlElements/Proxy/TypifiedElementCollectionProxy.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * This file is part of the QA-Tools library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/qa-tools/qa-tools
+ */
+
+namespace QATools\QATools\HtmlElements\Proxy;
+
+
+use QATools\QATools\HtmlElements\Element\AbstractTypifiedElementCollection;
+use QATools\QATools\HtmlElements\Element\ITypifiedElement;
+use QATools\QATools\PageObject\Element\AbstractElementCollection;
+
+/**
+ * Class for lazy-proxy creation to ensure, that TypifiedElementCollection are
+ * really accessed only at moment, when user needs them.
+ *
+ * @method \Mockery\Expectation shouldReceive(string $name)
+ *
+ * @link http://bit.ly/14TbcR9
+ */
+class TypifiedElementCollectionProxy extends TypifiedElementProxy
+{
+
+	/**
+	 * Offset to set.
+	 *
+	 * @param mixed $index  The offset to assign the value to.
+	 * @param mixed $newval The value to set.
+	 *
+	 * @return void
+	 * @throws \InvalidArgumentException When invalid element given.
+	 */
+	public function offsetSet($index, $newval)
+	{
+		$this->getObject()->offsetSet($index, $newval);
+	}
+
+	/**
+	 * Whether an offset exists.
+	 *
+	 * @param mixed $index An offset to check for.
+	 *
+	 * @return boolean
+	 */
+	public function offsetExists($index)
+	{
+		return $this->getObject()->offsetExists($index);
+	}
+
+	/**
+	 * Offset to unset.
+	 *
+	 * @param mixed $index The offset to unset.
+	 *
+	 * @return void
+	 */
+	public function offsetUnset($index)
+	{
+		$this->getObject()->offsetUnset($index);
+	}
+
+	/**
+	 * Offset to retrieve.
+	 *
+	 * @param mixed $index The offset to retrieve.
+	 *
+	 * @return mixed|null
+	 */
+	public function offsetGet($index)
+	{
+		return $this->getObject()->offsetGet($index);
+	}
+
+	/**
+	 * Count elements of an object.
+	 *
+	 * @return integer
+	 */
+	public function count()
+	{
+		return $this->getObject()->count();
+	}
+
+	/**
+	 * Returns the array iterator.
+	 *
+	 * @return \ArrayIterator
+	 */
+	public function getIterator()
+	{
+		return $this->getObject()->getIterator();
+	}
+
+	/**
+	 * Sets proxy's container to the collection.
+	 *
+	 * @return void
+	 */
+	protected function injectContainer()
+	{
+		$this->getObject()->setContainer($this->getContainer());
+	}
+
+	/**
+	 * Locates object inside proxy.
+	 *
+	 * @return void
+	 */
+	protected function locateObject()
+	{
+		if ( $this->locatorUsed ) {
+			return;
+		}
+
+		// NodeElement + TargetElement(setContainer) = Proxy.
+		$this->locatorUsed = true;
+
+		$object = call_user_func(
+			array($this->className, 'fromNodeElements'), $this->locateElements(), null, $this->pageFactory
+		);
+
+		AbstractElementCollection::offsetSet(null, $object);
+
+		$iterator = $this->getIterator();
+
+		/** @var ITypifiedElement $element */
+		foreach ( $iterator as $element ) {
+			$element->setName($this->getName());
+		}
+
+		$iterator->rewind();
+		$this->injectContainer();
+	}
+
+	/**
+	 * Returns class instance, that was placed inside a proxy.
+	 *
+	 * @return AbstractTypifiedElementCollection
+	 */
+	public function getObject()
+	{
+		$this->locateObject();
+
+		return \ArrayObject::getIterator()->current();
+	}
+
+}

--- a/library/QATools/QATools/HtmlElements/Proxy/TypifiedElementProxy.php
+++ b/library/QATools/QATools/HtmlElements/Proxy/TypifiedElementProxy.php
@@ -49,35 +49,30 @@ class TypifiedElementProxy extends AbstractProxy implements ITypifiedElement
 	}
 
 	/**
-	 * Returns class instance, that was placed inside a proxy.
+	 * Locates object inside proxy.
 	 *
-	 * @return ITypifiedElement
+	 * @return void
 	 */
-	public function getObject()
+	protected function locateObject()
 	{
-		if ( !$this->locatorUsed ) {
-			// NodeElement + WebElement(setContainer) + TargetElement(setName) = Proxy.
-			$this->locatorUsed = true;
-			/* @var $object ITypifiedElement */
+		if ( $this->locatorUsed ) {
+			return;
+		}
 
-			if ( $this->isElementCollection() ) {
-				$object = call_user_func(
-					array($this->className, 'fromNodeElements'), $this->locateElements(), null, $this->pageFactory
-				);
-			}
-			else {
-				$object = call_user_func(
-					array($this->className, 'fromNodeElement'), $this->locateElement(), $this->pageFactory
-				);
-			}
+		// NodeElement + WebElement(setContainer) + TargetElement(setName) = Proxy.
+		$this->locatorUsed = true;
+
+		foreach ( $this->locateElements() as $element ) {
+			/* @var $object ITypifiedElement */
+			$object = call_user_func(
+				array($this->className, 'fromNodeElement'), $element, $this->pageFactory
+			);
 
 			$object->setName($this->getName());
 			$this[] = $object;
-
-			$this->injectContainer();
 		}
 
-		return $this->getIterator()->current();
+		$this->injectContainer();
 	}
 
 	/**

--- a/library/QATools/QATools/PageObject/Element/AbstractElementCollection.php
+++ b/library/QATools/QATools/PageObject/Element/AbstractElementCollection.php
@@ -72,19 +72,19 @@ abstract class AbstractElementCollection extends \ArrayObject
 	/**
 	 * Offset to set.
 	 *
-	 * @param integer $offset The offset to assign the value to.
-	 * @param mixed   $value  The value to set.
+	 * @param mixed $index  The offset to assign the value to.
+	 * @param mixed $newval The value to set.
 	 *
 	 * @return void
 	 * @throws \InvalidArgumentException When invalid element given.
 	 */
-	public function offsetSet($offset, $value)
+	public function offsetSet($index, $newval)
 	{
-		if ( !$this->assertElement($value) ) {
+		if ( !$this->assertElement($newval) ) {
 			return;
 		}
 
-		parent::offsetSet($offset, $value);
+		parent::offsetSet($index, $newval);
 	}
 
 	/**

--- a/library/QATools/QATools/PageObject/ElementLocator/WaitingElementLocator.php
+++ b/library/QATools/QATools/PageObject/ElementLocator/WaitingElementLocator.php
@@ -11,11 +11,11 @@
 namespace QATools\QATools\PageObject\ElementLocator;
 
 
+use Behat\Mink\Element\NodeElement;
+use mindplay\annotations\AnnotationManager;
 use QATools\QATools\PageObject\Annotation\TimeoutAnnotation;
 use QATools\QATools\PageObject\ISearchContext;
 use QATools\QATools\PageObject\Property;
-use Behat\Mink\Element\NodeElement;
-use mindplay\annotations\AnnotationManager;
 
 /**
  * Class, that locates WebElements that might not be present at the moment.

--- a/library/QATools/QATools/PageObject/PropertyDecorator/DefaultPropertyDecorator.php
+++ b/library/QATools/QATools/PageObject/PropertyDecorator/DefaultPropertyDecorator.php
@@ -50,6 +50,7 @@ class DefaultPropertyDecorator implements IPropertyDecorator
 	 */
 	protected $elementToProxyMapping = array(
 		'\\QATools\\QATools\\PageObject\\Element\\IWebElement' => '\\QATools\\QATools\\PageObject\\Proxy\\WebElementProxy',
+		'\\QATools\\QATools\\PageObject\\Element\\WebElementCollection' => '\\QATools\\QATools\\PageObject\\Proxy\\WebElementCollectionProxy',
 	);
 
 	/**

--- a/library/QATools/QATools/PageObject/Proxy/AbstractProxy.php
+++ b/library/QATools/QATools/PageObject/Proxy/AbstractProxy.php
@@ -177,16 +177,6 @@ abstract class AbstractProxy extends AbstractElementCollection implements IProxy
 	}
 
 	/**
-	 * Determines if a class to proxy in fact is an element collection.
-	 *
-	 * @return boolean
-	 */
-	protected function isElementCollection()
-	{
-		return is_subclass_of($this->className, 'QATools\\QATools\\PageObject\\Element\\AbstractElementCollection');
-	}
-
-	/**
 	 * Sets proxy's container to each element.
 	 *
 	 * @return void
@@ -195,12 +185,115 @@ abstract class AbstractProxy extends AbstractElementCollection implements IProxy
 	{
 		$container = $this->getContainer();
 
+		$iterator = $this->getIterator();
+
 		/** @var IContainerAware $element */
-		foreach ( $this as $element ) {
+		foreach ( $iterator as $element ) {
 			$element->setContainer($container);
 		}
 
-		$this->getIterator()->rewind();
+		$iterator->rewind();
+	}
+
+	/**
+	 * Offset to set.
+	 *
+	 * @param mixed $index  The offset to assign the value to.
+	 * @param mixed $newval The value to set.
+	 *
+	 * @return void
+	 * @throws \InvalidArgumentException When invalid element given.
+	 */
+	public function offsetSet($index, $newval)
+	{
+		$this->locateObject();
+
+		parent::offsetSet($index, $newval);
+	}
+
+	/**
+	 * Whether a offset exists.
+	 *
+	 * @param mixed $index An offset to check for.
+	 *
+	 * @return boolean
+	 */
+	public function offsetExists($index)
+	{
+		$this->locateObject();
+
+		return parent::offsetExists($index);
+	}
+
+	/**
+	 * Offset to unset.
+	 *
+	 * @param mixed $index The offset to unset.
+	 *
+	 * @return void
+	 */
+	public function offsetUnset($index)
+	{
+		$this->locateObject();
+
+		parent::offsetUnset($index);
+	}
+
+	/**
+	 * Offset to retrieve.
+	 *
+	 * @param mixed $index The offset to retrieve.
+	 *
+	 * @return mixed|null
+	 */
+	public function offsetGet($index)
+	{
+		$this->locateObject();
+
+		return parent::offsetGet($index);
+	}
+
+	/**
+	 * Count elements of an object.
+	 *
+	 * @return integer
+	 */
+	public function count()
+	{
+		$this->locateObject();
+
+		return parent::count();
+	}
+
+	/**
+	 * Returns the array iterator.
+	 *
+	 * @return \ArrayIterator
+	 */
+	public function getIterator()
+	{
+		$this->locateObject();
+
+		return parent::getIterator();
+	}
+
+	/**
+	 * Locates object inside proxy.
+	 *
+	 * @return mixed
+	 */
+	protected abstract function locateObject();
+
+	/**
+	 * Returns class instance, that was placed inside a proxy.
+	 *
+	 * @return mixed
+	 */
+	public function getObject()
+	{
+		$this->locateObject();
+
+		return $this->getIterator()->current();
 	}
 
 }

--- a/library/QATools/QATools/PageObject/Proxy/WebElementCollectionProxy.php
+++ b/library/QATools/QATools/PageObject/Proxy/WebElementCollectionProxy.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * This file is part of the QA-Tools library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/qa-tools/qa-tools
+ */
+
+namespace QATools\QATools\PageObject\Proxy;
+
+
+use QATools\QATools\PageObject\Element\WebElementCollection;
+
+/**
+ * Class for lazy-proxy creation to ensure, that WebElementCollection are
+ * really accessed only at moment, when user needs them.
+ *
+ * @method \Mockery\Expectation shouldReceive(string $name)
+ *
+ * @link http://bit.ly/14TbcR9
+ */
+class WebElementCollectionProxy extends WebElementProxy
+{
+
+	/**
+	 * Offset to set.
+	 *
+	 * @param mixed $index  The offset to assign the value to.
+	 * @param mixed $newval The value to set.
+	 *
+	 * @return void
+	 * @throws \InvalidArgumentException When invalid element given.
+	 */
+	public function offsetSet($index, $newval)
+	{
+		$this->getObject()->offsetSet($index, $newval);
+	}
+
+	/**
+	 * Whether an offset exists.
+	 *
+	 * @param mixed $index An offset to check for.
+	 *
+	 * @return boolean
+	 */
+	public function offsetExists($index)
+	{
+		return $this->getObject()->offsetExists($index);
+	}
+
+	/**
+	 * Offset to unset.
+	 *
+	 * @param mixed $index The offset to unset.
+	 *
+	 * @return void
+	 */
+	public function offsetUnset($index)
+	{
+		$this->getObject()->offsetUnset($index);
+	}
+
+	/**
+	 * Offset to retrieve.
+	 *
+	 * @param mixed $index The offset to retrieve.
+	 *
+	 * @return mixed|null
+	 */
+	public function offsetGet($index)
+	{
+		return $this->getObject()->offsetGet($index);
+	}
+
+	/**
+	 * Count elements of an object.
+	 *
+	 * @return integer
+	 */
+	public function count()
+	{
+		return $this->getObject()->count();
+	}
+
+	/**
+	 * Returns the array iterator.
+	 *
+	 * @return \ArrayIterator
+	 */
+	public function getIterator()
+	{
+		return $this->getObject()->getIterator();
+	}
+
+	/**
+	 * Sets proxy's container to the collection.
+	 *
+	 * @return void
+	 */
+	protected function injectContainer()
+	{
+		$this->getObject()->setContainer($this->getContainer());
+	}
+
+	/**
+	 * Locates object inside proxy.
+	 *
+	 * @return void
+	 */
+	protected function locateObject()
+	{
+		if ( $this->locatorUsed ) {
+			return;
+		}
+
+		// NodeElement + TargetElement(setContainer) = Proxy.
+		$this->locatorUsed = true;
+
+		$object = call_user_func(
+			array($this->className, 'fromNodeElements'), $this->locateElements(), null, $this->pageFactory
+		);
+
+		\ArrayObject::offsetSet(null, $object);
+		$this->injectContainer();
+	}
+
+	/**
+	 * Returns class instance, that was placed inside a proxy.
+	 *
+	 * @return WebElementCollection
+	 */
+	public function getObject()
+	{
+		$this->locateObject();
+
+		return \ArrayObject::getIterator()->current();
+	}
+
+}

--- a/library/QATools/QATools/PageObject/Proxy/WebElementProxy.php
+++ b/library/QATools/QATools/PageObject/Proxy/WebElementProxy.php
@@ -13,7 +13,6 @@ namespace QATools\QATools\PageObject\Proxy;
 
 use QATools\QATools\PageObject\Element\IWebElement;
 use QATools\QATools\PageObject\ElementLocator\IElementLocator;
-use QATools\QATools\PageObject\Element\WebElement;
 use QATools\QATools\PageObject\IPageFactory;
 
 /**
@@ -41,33 +40,29 @@ class WebElementProxy extends AbstractProxy implements IWebElement
 	}
 
 	/**
-	 * Returns class instance, that was placed inside a proxy.
+	 * Locates object inside proxy.
 	 *
-	 * @return WebElement
+	 * @return void
 	 */
-	public function getObject()
+	protected function locateObject()
 	{
-		if ( !$this->locatorUsed ) {
-			// NodeElement + TargetElement(setContainer) = Proxy.
-			$this->locatorUsed = true;
-			/* @var $object IWebElement */
-
-			if ( $this->isElementCollection() ) {
-				$object = call_user_func(
-					array($this->className, 'fromNodeElements'), $this->locateElements(), null, $this->pageFactory
-				);
-			}
-			else {
-				$object = call_user_func(
-					array($this->className, 'fromNodeElement'), $this->locateElement(), $this->pageFactory
-				);
-			}
-
-			$this[] = $object;
-			$this->injectContainer();
+		if ( $this->locatorUsed ) {
+			return;
 		}
 
-		return $this->getIterator()->current();
+		// NodeElement + TargetElement(setContainer) = Proxy.
+		$this->locatorUsed = true;
+
+		foreach ( $this->locateElements() as $element ) {
+			/* @var $object IWebElement */
+			$object = call_user_func(
+				array($this->className, 'fromNodeElement'), $element, $this->pageFactory
+			);
+
+			$this[] = $object;
+		}
+
+		$this->injectContainer();
 	}
 
 }

--- a/tests/QATools/QATools/HtmlElements/Element/RadioGroupTest.php
+++ b/tests/QATools/QATools/HtmlElements/Element/RadioGroupTest.php
@@ -144,6 +144,18 @@ class RadioGroupTest extends TypifiedElementCollectionTest
 		$this->assertSame($element, $element->setValue(555));
 	}
 
+	public function testSetContainer()
+	{
+		$container = m::mock('\\QATools\\QATools\\PageObject\\ISearchContext');
+
+		$element = $this->createRadioButton();
+		$element->shouldReceive('setContainer')->with($container)->once();
+
+		$this->element[] = $element;
+
+		$this->assertSame($this->element, $this->element->setContainer($container));
+	}
+
 	/**
 	 * Creates a radio button.
 	 *

--- a/tests/QATools/QATools/HtmlElements/Element/TypifiedElementCollectionTest.php
+++ b/tests/QATools/QATools/HtmlElements/Element/TypifiedElementCollectionTest.php
@@ -11,8 +11,8 @@
 namespace tests\QATools\QATools\HtmlElements\Element;
 
 
-use QATools\QATools\HtmlElements\Element\AbstractTypifiedElementCollection;
 use Mockery as m;
+use QATools\QATools\HtmlElements\Element\AbstractTypifiedElementCollection;
 use QATools\QATools\PageObject\Element\WebElement;
 use tests\QATools\QATools\PageObject\Element\AbstractElementCollectionTestCase;
 
@@ -51,6 +51,11 @@ class TypifiedElementCollectionTest extends AbstractElementCollectionTestCase
 	public function testSetContainer()
 	{
 		$container = m::mock('\\QATools\\QATools\\PageObject\\ISearchContext');
+
+		$element = $this->createValidElementMock();
+		$element->shouldReceive('setContainer')->with($container)->once();
+
+		$this->element[] = $element;
 
 		$this->assertSame($this->element, $this->element->setContainer($container));
 	}

--- a/tests/QATools/QATools/HtmlElements/Fixture/Element/AlternateTypifiedElementCollection.php
+++ b/tests/QATools/QATools/HtmlElements/Fixture/Element/AlternateTypifiedElementCollection.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * This file is part of the QA-Tools library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/qa-tools/qa-tools
+ */
+
+namespace tests\QATools\QATools\HtmlElements\Fixture\Element;
+
+
+class AlternateTypifiedElementCollection extends TypifiedElementCollectionChild
+{
+}

--- a/tests/QATools/QATools/HtmlElements/Proxy/TypifiedElementCollectionProxyTest.php
+++ b/tests/QATools/QATools/HtmlElements/Proxy/TypifiedElementCollectionProxyTest.php
@@ -19,9 +19,27 @@ class TypifiedElementCollectionProxyTest extends TypifiedElementProxyTest
 
 	const ELEMENT_CLASS = '\\tests\\QATools\\QATools\\HtmlElements\\Fixture\\Element\\TypifiedElementCollectionChild';
 
+	protected function setUp()
+	{
+		if ( is_null($this->collectionClass) ) {
+			$this->collectionClass = '\\QATools\\QATools\\HtmlElements\\Proxy\\TypifiedElementCollectionProxy';
+			$this->collectionElementClass = '\\QATools\\QATools\\HtmlElements\\Element\\TextInput';
+		}
+
+		parent::setUp();
+	}
+
 	public function testDefaultClassName()
 	{
 		$this->assertInstanceOf(self::ELEMENT_CLASS, $this->element->getObject());
+	}
+
+	public function testSetClassName()
+	{
+		$expected = '\\tests\\QATools\\QATools\\HtmlElements\\Fixture\\Element\\AlternateTypifiedElementCollection';
+
+		$this->element->setClassName($expected);
+		$this->assertInstanceOf($expected, $this->element->getObject());
 	}
 
 	public function testMethodForwardingSuccess()

--- a/tests/QATools/QATools/Live/HtmlElements/Element/TypifiedElementTestCase.php
+++ b/tests/QATools/QATools/Live/HtmlElements/Element/TypifiedElementTestCase.php
@@ -15,7 +15,6 @@ use Behat\Mink\Mink;
 use Behat\Mink\Session;
 use QATools\QATools\HtmlElements\Element\AbstractTypifiedElement;
 use QATools\QATools\PageObject\Element\WebElement;
-use QATools\QATools\PageObject\PageFactory;
 use tests\QATools\QATools\Live\AbstractLiveTestCase;
 
 class TypifiedElementTestCase extends AbstractLiveTestCase

--- a/tests/QATools/QATools/Live/HtmlElements/Pages/TypifiedElementPage.php
+++ b/tests/QATools/QATools/Live/HtmlElements/Pages/TypifiedElementPage.php
@@ -52,4 +52,12 @@ class TypifiedElementPage extends TypifiedPage
 	 */
 	public $radioGroup;
 
+	/**
+	 * Example text inputs as TextInput.
+	 *
+	 * @var TextInput[]
+	 * @find-by('css' => '.test-input')
+	 */
+	public $textInputs;
+
 }

--- a/tests/QATools/QATools/Live/HtmlElements/TypifiedPageTest.php
+++ b/tests/QATools/QATools/Live/HtmlElements/TypifiedPageTest.php
@@ -55,12 +55,59 @@ class TypifiedPageTest extends AbstractLiveTestCase
 		$page = new TypifiedElementPage($this->pageFactory);
 
 		$this->assertFalse($page->radioGroup->hasSelectedButton(), 'No radio button is selected initially');
-		$this->assertCount(1, $page->radioGroup);
+		$this->assertCount(4, $page->radioGroup);
 
 		for ( $i = 1; $i <= 4; $i++ ) {
 			$page->radioGroup->selectButtonByValue($i);
 			$this->assertEquals($i, $page->radioGroup->getSelectedButton()->getValue());
 		}
+
+		$count = 0;
+
+		foreach ( $page->radioGroup as $index => $radio ) {
+			$count++;
+			$radio->select();
+
+			$this->assertEquals($page->radioGroup[$index], $radio);
+			$this->assertEquals($index + 1, $page->radioGroup->getSelectedButton()->getValue());
+		}
+
+		$this->assertEquals(4, $count);
+	}
+
+	public function testTextInputsLocatedByCss()
+	{
+		/** @var TypifiedElementPage $page */
+		$page = new TypifiedElementPage($this->pageFactory);
+
+		$this->assertCount(3, $page->textInputs);
+
+		$page->textInputs->setValue('text');
+
+		$this->assertEquals('text', $page->textInputs[0]->getText());
+		$this->assertNotEquals('text', $page->textInputs[1]->getText());
+		$this->assertNotEquals('text', $page->textInputs[2]->getText());
+
+		$count = 0;
+
+		foreach ( $page->textInputs as $index => $input ) {
+			$count++;
+			$input->setValue('text' . $index);
+		}
+
+		$this->assertEquals(3, $count);
+
+		$this->assertEquals('text0', $page->textInputs[0]->getText());
+		$this->assertEquals('text1', $page->textInputs[1]->getText());
+		$this->assertEquals('text2', $page->textInputs[2]->getText());
+
+		foreach ( $page->textInputs as $input ) {
+			$input->clear();
+		}
+
+		$this->assertEquals('', $page->textInputs[0]->getText());
+		$this->assertEquals('', $page->textInputs[1]->getText());
+		$this->assertEquals('', $page->textInputs[2]->getText());
 	}
 
 }

--- a/tests/QATools/QATools/Live/PageObject/PageTest.php
+++ b/tests/QATools/QATools/Live/PageObject/PageTest.php
@@ -55,11 +55,50 @@ class PageTest extends AbstractLiveTestCase
 		$page = new WebElementPage($this->pageFactory);
 
 		$this->assertFalse($page->radioGroup->isChecked());
-		$this->assertCount(1, $page->radioGroup);
+		$this->assertCount(4, $page->radioGroup);
 
 		$page->radioGroup->selectOption('1');
 
 		$this->assertTrue($page->radioGroup->isSelected());
+
+		$count = 0;
+
+		foreach ( $page->radioGroup as $index => $radio ) {
+			$count++;
+			$radio->click();
+
+			$this->assertEquals($page->radioGroup[$index], $radio);
+			$this->assertEquals($index + 1, $radio->getValue());
+		}
+
+		$this->assertEquals(4, $count);
+	}
+
+	public function testTextInputsLocatedByCss()
+	{
+		/** @var WebElementPage $page */
+		$page = new WebElementPage($this->pageFactory);
+
+		$this->assertCount(3, $page->textInputs);
+
+		$page->textInputs->setValue('text');
+
+		$this->assertEquals('text', $page->textInputs[0]->getValue());
+		$this->assertNotEquals('text', $page->textInputs[1]->getValue());
+		$this->assertNotEquals('text', $page->textInputs[2]->getValue());
+
+		$count = 0;
+
+		foreach ( $page->textInputs as $index => $input ) {
+			$count++;
+			$input->setValue('text' . $index);
+		}
+
+		$this->assertEquals(3, $count);
+
+		$this->assertEquals('text0', $page->textInputs[0]->getValue());
+		$this->assertEquals('text1', $page->textInputs[1]->getValue());
+		$this->assertEquals('text2', $page->textInputs[2]->getValue());
 	}
 
 }

--- a/tests/QATools/QATools/Live/PageObject/Pages/WebElementPage.php
+++ b/tests/QATools/QATools/Live/PageObject/Pages/WebElementPage.php
@@ -36,8 +36,16 @@ class WebElementPage extends Page
 	/**
 	 * Example radio buttons as WebElement.
 	 *
-	 * @var WebElement
+	 * @var WebElement[]
 	 * @find-by('name' => 'radio-group1')
 	 */
 	public $radioGroup;
+
+	/**
+	 * Example text inputs as WebElement.
+	 *
+	 * @var WebElement[]
+	 * @find-by('css' => '.test-input')
+	 */
+	public $textInputs;
 }

--- a/tests/QATools/QATools/Live/PageObject/index.html
+++ b/tests/QATools/QATools/Live/PageObject/index.html
@@ -105,6 +105,11 @@
 		<div class="first second third"></div>
 	</div>
 
+	<div class="grouped-inputs">
+		<input class="test-input" name="test1">
+		<input class="test-input" name="test2">
+		<input class="test-input" name="test3">
+	</div>
 
   <form id="test-form">
     <button id="generate-btn">generate element</button>

--- a/tests/QATools/QATools/PageObject/Element/AbstractElementCollectionTestCase.php
+++ b/tests/QATools/QATools/PageObject/Element/AbstractElementCollectionTestCase.php
@@ -63,23 +63,25 @@ abstract class AbstractElementCollectionTestCase extends TestCase
 	{
 		$element = $this->createValidElementMock();
 
-		$this->assertCount(0, $this->element);
-		$this->element[] = $element;
-		$this->element[0] = $element;
-		$this->assertCount(1, $this->element);
+		$initial_count = count($this->element);
+		$new_count = $initial_count + 1;
 
-		$this->assertSame($element, $this->element[0]);
+		$this->element[] = $element;
+		$this->element[$initial_count] = $element;
+		$this->assertCount($new_count, $this->element);
+
+		$this->assertSame($element, $this->element[$initial_count]);
 
 		try {
-			$this->assertNull($this->element[1]);
+			$this->assertNull($this->element[$new_count]);
 		}
 		catch ( \PHPUnit_Framework_Error_Notice $e ) {
 			// Ignore notice.
 		}
 
-		$this->assertTrue(isset($this->element[0]));
-		unset($this->element[0]);
-		$this->assertFalse(isset($this->element[0]));
+		$this->assertArrayHasKey($initial_count, $this->element);
+		unset($this->element[$initial_count]);
+		$this->assertArrayNotHasKey($initial_count, $this->element);
 	}
 
 	/**
@@ -87,6 +89,8 @@ abstract class AbstractElementCollectionTestCase extends TestCase
 	 */
 	public function testIteratorInterface()
 	{
+		$start_index = count($this->element);
+
 		$elements = array(
 			$this->createValidElementMock(),
 			$this->createValidElementMock(),
@@ -98,7 +102,11 @@ abstract class AbstractElementCollectionTestCase extends TestCase
 		}
 
 		foreach ( $this->element as $index => $element ) {
-			$this->assertSame($elements[$index], $element, 'element at correct index returned');
+			if ( $index < $start_index ) {
+				continue;
+			}
+
+			$this->assertSame($elements[$index - $start_index], $element, 'element at correct index returned');
 		}
 	}
 

--- a/tests/QATools/QATools/PageObject/Element/WebElementCollectionTest.php
+++ b/tests/QATools/QATools/PageObject/Element/WebElementCollectionTest.php
@@ -30,6 +30,11 @@ class WebElementCollectionTest extends AbstractElementCollectionTestCase
 	{
 		$container = m::mock('\\QATools\\QATools\\PageObject\\ISearchContext');
 
+		$element = $this->createValidElementMock();
+		$element->shouldReceive('setContainer')->with($container)->once();
+
+		$this->element[] = $element;
+
 		$this->assertSame($this->element, $this->element->setContainer($container));
 	}
 

--- a/tests/QATools/QATools/PageObject/ElementLocator/WaitingElementLocatorTest.php
+++ b/tests/QATools/QATools/PageObject/ElementLocator/WaitingElementLocatorTest.php
@@ -27,14 +27,19 @@ class WaitingElementLocatorTest extends DefaultElementLocatorTest
 		parent::setUp();
 	}
 
-	public function testGetSelectorSuccessWithTimeout()
+	/**
+	 * @dataProvider selectorProvider
+	 */
+	public function testGetSelectorsSuccessWithTimeout(array $selectors)
 	{
 		$search_context = $this->searchContext;
 		$node_element = m::mock('\\Behat\\Mink\\Element\\NodeElement');
 
-		$expected = array('xpath' => 'xpath1');
-		$this->expectFindByAnnotation($expected);
-		$this->searchContext->shouldReceive('findAll')->with('se', $expected)->andReturn(array($node_element));
+		$this->expectFindByAnnotations($selectors);
+
+		foreach ( $selectors as $selector ) {
+			$this->searchContext->shouldReceive('findAll')->with('se', $selector)->andReturn(array($node_element));
+		}
 
 		$this->searchContext
 			->shouldReceive('waitFor')
@@ -46,7 +51,7 @@ class WaitingElementLocatorTest extends DefaultElementLocatorTest
 
 		$found_elements = $this->locator->findAll();
 
-		$this->assertCount(1, $found_elements);
+		$this->assertCount(count($selectors), $found_elements);
 		$this->assertSame($node_element, $found_elements[0]);
 	}
 

--- a/tests/QATools/QATools/PageObject/Proxy/AbstractProxyTestCase.php
+++ b/tests/QATools/QATools/PageObject/Proxy/AbstractProxyTestCase.php
@@ -46,7 +46,7 @@ abstract class AbstractProxyTestCase extends AbstractElementCollectionTestCase
 	 */
 	protected $ignoreLocatorTests = array(
 		'testSetContainer', 'testGetContainerFallback', 'testGetObjectEmptyLocator', 'testIsValidSubstitute',
-		'testSetName', 'testArrayAccessInterface', 'testIteratorInterface', 'testFromNodeElements',
+		'testSetName', 'testFromNodeElements',
 	);
 
 	protected function setUp()

--- a/tests/QATools/QATools/PageObject/Proxy/WebElementCollectionProxyTest.php
+++ b/tests/QATools/QATools/PageObject/Proxy/WebElementCollectionProxyTest.php
@@ -17,6 +17,14 @@ use Mockery as m;
 class WebElementCollectionProxyTest extends WebElementProxyTest
 {
 
+	protected function setUp()
+	{
+		$this->collectionClass = '\\QATools\\QATools\\PageObject\\Proxy\\WebElementCollectionProxy';
+		$this->collectionElementClass = '\\QATools\\QATools\\PageObject\\Element\\WebElement';
+
+		parent::setUp();
+	}
+
 	public function testDefaultClassName()
 	{
 		$expected = '\\QATools\\QATools\\PageObject\\Element\\WebElementCollection';
@@ -27,6 +35,14 @@ class WebElementCollectionProxyTest extends WebElementProxyTest
 	public function testMethodForwardingSuccess()
 	{
 		$this->assertEquals(1, $this->element->proxyMe());
+	}
+
+	public function testSetClassName()
+	{
+		$expected = '\\QATools\\QATools\\PageObject\\Element\\WebElementCollection';
+
+		$this->element->setClassName($expected);
+		$this->assertInstanceOf($expected, $this->element->getObject());
 	}
 
 	/**


### PR DESCRIPTION
Still open tasks but basic support for multiple `@find-by`. Still requiring some new unit tests and `ElementCollection` see #48 for more details.

Closes #13
