### PR TITLE
Realigned menu to left and inline-block.

### DIFF
--- a/public/css/hyde.css
+++ b/public/css/hyde.css
@@ -92,6 +92,8 @@ html {
 .sidebar-nav {
   padding-left: 0;
   list-style: none;
+  text-align: left;
+  display: inline-block;
 }
 .sidebar-nav ul {
 	margin-bottom: 0;


### PR DESCRIPTION
Fixed menu which had bad text alignment on mobile devices.

Fix is to make the menu `inline-block` and switch text-align to `left`. Works for desktop and mobile.
