### PR TITLE
Failing test to catch decorator inability to handle properties with interfaces

### DIFF
--- a/tests/aik099/QATools/PageObject/Fixture/InterfaceAnnotatedClass.php
+++ b/tests/aik099/QATools/PageObject/Fixture/InterfaceAnnotatedClass.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This file is part of the qa-tools library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/aik099/qa-tools
+ */
+
+namespace tests\aik099\QATools\PageObject\Fixture;
+
+
+class InterfaceAnnotatedClass
+{
+
+	/**
+	 * Testing property using an Interface as type.
+	 *
+	 * @var IExampleAnnotation
+	 */
+	protected $property;
+
+}
+
+interface IExampleAnnotation
+{
+
+}

--- a/tests/aik099/QATools/PageObject/PropertyDecorator/DefaultPropertyDecoratorTest.php
+++ b/tests/aik099/QATools/PageObject/PropertyDecorator/DefaultPropertyDecoratorTest.php
@@ -11,14 +11,18 @@
 namespace tests\aik099\QATools\PageObject\PropertyDecorator;
 
 
-use aik099\QATools\PageObject\Proxy\IProxy;
-use aik099\QATools\PageObject\ISearchContext;
-use Mockery as m;
+use aik099\QATools\PageObject\ElementLocator\DefaultElementLocatorFactory;
 use aik099\QATools\PageObject\ElementLocator\IElementLocator;
 use aik099\QATools\PageObject\ElementLocator\IElementLocatorFactory;
+use aik099\QATools\PageObject\IPageFactory;
+use aik099\QATools\PageObject\ISearchContext;
 use aik099\QATools\PageObject\Property;
 use aik099\QATools\PageObject\PropertyDecorator\IPropertyDecorator;
+use aik099\QATools\PageObject\Proxy\IProxy;
 use aik099\QATools\PageObject\Proxy\WebElementProxy;
+use mindplay\annotations\AnnotationCache;
+use mindplay\annotations\AnnotationManager;
+use Mockery as m;
 use tests\aik099\QATools\TestCase;
 
 class DefaultPropertyDecoratorTest extends TestCase
@@ -182,6 +186,34 @@ class DefaultPropertyDecoratorTest extends TestCase
 		return array(
 			array('\\aik099\\QATools\\PageObject\\Element\\WebElement', '\\aik099\\QATools\\PageObject\\Proxy\\WebElementProxy'),
 		);
+	}
+
+	public function testInterfacesAreNotDecorated()
+	{
+		/** @var $search_context ISearchContext */
+		$search_context = m::mock('\\aik099\\QATools\\PageObject\\ISearchContext');
+		$annotation_manager = new AnnotationManager();
+		$annotation_manager->cache = new AnnotationCache(sys_get_temp_dir());
+
+		/** @var $page_factory IPageFactory */
+		$page_factory = m::mock('\\aik099\\QATools\\PageObject\\IPageFactory');
+		$locator_factory = new DefaultElementLocatorFactory($search_context, $annotation_manager);
+
+		/** @var $decorator IPropertyDecorator */
+		$decorator = new $this->decoratorClass($locator_factory, $page_factory);
+		$reflection_class = new \ReflectionClass(
+			'\\tests\\aik099\QATools\\PageObject\\Fixture\\InterfaceAnnotatedClass'
+		);
+
+		$properties = $reflection_class->getProperties();
+
+		foreach ( $properties as $reflected_property ) {
+			$property = new Property($reflected_property, $annotation_manager);
+
+			$proxy = $decorator->decorate($property);
+
+			$this->assertNull($proxy);
+		}
 	}
 
 }


### PR DESCRIPTION
It turns out that decorator is creating a locator (in the `decorate` method) upfront without even checking if a property can be decorated or not. In particular case properties, whose `@var` annotation has as interface name won't be decorated.

This wasn't noticed until introduction of `WaitingElementLocator`, which searches for `@timeout` annotation in constructor, which results in attempt to introspect the interface from `@var` annotation of processed Page class property (see php-annotations/php-annotations#57).

This is semi-integration test to prove that described problem exists.
