### PR TITLE
Remove PHPDoc in Test.php files

### DIFF
--- a/tests/aik099/QATools/BEM/Annotation/BEMAnnotationTest.php
+++ b/tests/aik099/QATools/BEM/Annotation/BEMAnnotationTest.php
@@ -33,11 +33,6 @@ class BEMAnnotationTest extends \PHPUnit_Framework_TestCase
 	 */
 	private $_locatorHelper;
 
-	/**
-	 * Prepares test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		parent::setUp();
@@ -46,11 +41,6 @@ class BEMAnnotationTest extends \PHPUnit_Framework_TestCase
 		$this->_locatorHelper = m::mock('\\aik099\\QATools\\BEM\\ElementLocator\\LocatorHelper');
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetElementSelector()
 	{
 		$this->_annotation->block = 'block-name';
@@ -65,11 +55,6 @@ class BEMAnnotationTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals('OK', $this->_annotation->getSelector($this->_locatorHelper));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetElementSelectorWithModificator()
 	{
 		$this->_annotation->block = 'block-name';
@@ -85,11 +70,6 @@ class BEMAnnotationTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals('OK', $this->_annotation->getSelector($this->_locatorHelper));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetBlockSelector()
 	{
 		$this->_annotation->block = 'block-name';
@@ -103,11 +83,6 @@ class BEMAnnotationTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals('OK', $this->_annotation->getSelector($this->_locatorHelper));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetBlockSelectorWithModificator()
 	{
 		$this->_annotation->block = 'block-name';

--- a/tests/aik099/QATools/BEM/Element/BlockTest.php
+++ b/tests/aik099/QATools/BEM/Element/BlockTest.php
@@ -41,11 +41,6 @@ class BlockTest extends PartTestCase
 	 */
 	private $_elementLocator;
 
-	/**
-	 * Prepares mocks for object creation.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		parent::setUp();
@@ -65,11 +60,6 @@ class BlockTest extends PartTestCase
 		$this->_elementLocator = m::mock('\\aik099\\QATools\\BEM\\ElementLocator\\BEMElementLocator');
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testConstructor()
 	{
 		$block = $this->createPart();
@@ -78,12 +68,6 @@ class BlockTest extends PartTestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string $modificator_name  Modificator name.
-	 * @param string $modificator_value Modificator value.
-	 *
-	 * @return void
 	 * @dataProvider modificatorDataProvider
 	 */
 	public function testGetElement($modificator_name, $modificator_value)
@@ -103,12 +87,6 @@ class BlockTest extends PartTestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string $modificator_name  Modificator name.
-	 * @param string $modificator_value Modificator value.
-	 *
-	 * @return void
 	 * @dataProvider modificatorDataProvider
 	 */
 	public function testGetElementEmpty($modificator_name, $modificator_value)
@@ -128,12 +106,6 @@ class BlockTest extends PartTestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string $modificator_name  Modificator name.
-	 * @param string $modificator_value Modificator value.
-	 *
-	 * @return void
 	 * @dataProvider modificatorDataProvider
 	 */
 	public function testGetElements($modificator_name, $modificator_value)
@@ -155,12 +127,6 @@ class BlockTest extends PartTestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string $modificator_name  Modificator name.
-	 * @param string $modificator_value Modificator value.
-	 *
-	 * @return void
 	 * @dataProvider modificatorDataProvider
 	 */
 	public function testGetElementsEmpty($modificator_name, $modificator_value)
@@ -179,11 +145,6 @@ class BlockTest extends PartTestCase
 		$this->assertCount(0, $nodes);
 	}
 
-	/**
-	 * Provides test data for modificator testing.
-	 *
-	 * @return array
-	 */
 	public function modificatorDataProvider()
 	{
 		return array(
@@ -192,11 +153,6 @@ class BlockTest extends PartTestCase
 		);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testFind()
 	{
 		$this->_prepareSearchFixture();
@@ -207,11 +163,6 @@ class BlockTest extends PartTestCase
 		$this->assertEquals('sub-xpath-1', $node->getXpath());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testFindEmpty()
 	{
 		$this->_prepareSearchFixture(true);
@@ -222,11 +173,6 @@ class BlockTest extends PartTestCase
 		$this->assertNull($node);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testFindAll()
 	{
 		$this->_prepareSearchFixture();
@@ -239,11 +185,6 @@ class BlockTest extends PartTestCase
 		$this->assertEquals('sub-xpath-2', $nodes[1]->getXpath());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testFindAllEmpty()
 	{
 		$this->_prepareSearchFixture(true);

--- a/tests/aik099/QATools/BEM/Element/ElementTest.php
+++ b/tests/aik099/QATools/BEM/Element/ElementTest.php
@@ -26,11 +26,6 @@ class ElementTest extends PartTestCase
 	 */
 	private $_webElement;
 
-	/**
-	 * Prepares mocks for object creation.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		parent::setUp();
@@ -39,11 +34,6 @@ class ElementTest extends PartTestCase
 		$this->_webElement = m::mock('\\aik099\\QATools\\PageObject\\Element\\WebElement');
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testConstructor()
 	{
 		$element = $this->createPart();

--- a/tests/aik099/QATools/BEM/Element/PartTestCase.php
+++ b/tests/aik099/QATools/BEM/Element/PartTestCase.php
@@ -25,11 +25,6 @@ abstract class PartTestCase extends TestCase
 	 */
 	protected $partClass = '';
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetContainer()
 	{
 		$container = m::mock('\\aik099\\QATools\\PageObject\\ISearchContext');

--- a/tests/aik099/QATools/BEM/ElementLocator/BEMElementLocatorFactoryTest.php
+++ b/tests/aik099/QATools/BEM/ElementLocator/BEMElementLocatorFactoryTest.php
@@ -26,11 +26,6 @@ class BEMElementLocatorFactoryTest extends \PHPUnit_Framework_TestCase
 	 */
 	protected $locatorClass = '\\aik099\\QATools\\BEM\\ElementLocator\\BEMElementLocator';
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testCreateLocator()
 	{
 		$annotation_manager = m::mock('\\mindplay\\annotations\\AnnotationManager');

--- a/tests/aik099/QATools/BEM/ElementLocator/BEMElementLocatorTest.php
+++ b/tests/aik099/QATools/BEM/ElementLocator/BEMElementLocatorTest.php
@@ -38,11 +38,6 @@ class BEMElementLocatorTest extends DefaultElementLocatorTest
 	 */
 	private $_locatorHelper;
 
-	/**
-	 * Prepares page.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		$this->searchContextClass = '\\aik099\\QATools\\BEM\\Element\\IBlock';
@@ -52,11 +47,6 @@ class BEMElementLocatorTest extends DefaultElementLocatorTest
 		parent::setUp();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetSelectorSuccess()
 	{
 		$expected = array('xpath' => 'xpath1');
@@ -70,11 +60,6 @@ class BEMElementLocatorTest extends DefaultElementLocatorTest
 		$this->assertEquals('block-name', $annotation->block, 'block name set to element annotation from parent block');
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetSelectorBlock()
 	{
 		$expected = array('xpath' => 'xpath1');
@@ -89,9 +74,6 @@ class BEMElementLocatorTest extends DefaultElementLocatorTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\PageObject\Exception\AnnotationException
 	 * @expectedExceptionCode \aik099\QATools\PageObject\Exception\AnnotationException::TYPE_REQUIRED
 	 */
@@ -104,11 +86,6 @@ class BEMElementLocatorTest extends DefaultElementLocatorTest
 		$this->assertCount(0, $this->locator->findAll());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testToString()
 	{
 		$expected = 'OK';
@@ -134,11 +111,6 @@ class BEMElementLocatorTest extends DefaultElementLocatorTest
 		return $annotation;
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetBlockLocator()
 	{
 		$this->_locatorHelper
@@ -150,11 +122,6 @@ class BEMElementLocatorTest extends DefaultElementLocatorTest
 		$this->assertEquals('OK', $this->locator->getBlockLocator('block-name', 'modificator-name', 'modificator-value'));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetElementLocator()
 	{
 		$this->_locatorHelper

--- a/tests/aik099/QATools/BEM/ElementLocator/LocatorHelperTest.php
+++ b/tests/aik099/QATools/BEM/ElementLocator/LocatorHelperTest.php
@@ -23,11 +23,6 @@ class LocatorHelperTest extends \PHPUnit_Framework_TestCase
 	 */
 	private $_locatorHelper;
 
-	/**
-	 * Prepares the test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		parent::setUp();
@@ -36,9 +31,6 @@ class LocatorHelperTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\BEM\Exception\ElementException
 	 * @expectedExceptionCode \aik099\QATools\BEM\Exception\ElementException::TYPE_BLOCK_REQUIRED
 	 */
@@ -47,11 +39,6 @@ class LocatorHelperTest extends \PHPUnit_Framework_TestCase
 		$this->_locatorHelper->getBlockLocator('');
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetBlockLocator()
 	{
 		$locator = $this->_locatorHelper->getBlockLocator('block-name');
@@ -59,11 +46,6 @@ class LocatorHelperTest extends \PHPUnit_Framework_TestCase
 		$this->_assertLocatorClassName($locator, 'block-name');
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetBlockLocatorWithModificator()
 	{
 		$locator = $this->_locatorHelper->getBlockLocator('block-name', 'modificator-name', 'modificator-value');
@@ -72,9 +54,6 @@ class LocatorHelperTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\BEM\Exception\ElementException
 	 * @expectedExceptionCode \aik099\QATools\BEM\Exception\ElementException::TYPE_ELEMENT_REQUIRED
 	 */
@@ -84,9 +63,6 @@ class LocatorHelperTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\BEM\Exception\ElementException
 	 * @expectedExceptionCode \aik099\QATools\BEM\Exception\ElementException::TYPE_BLOCK_REQUIRED
 	 */
@@ -95,11 +71,6 @@ class LocatorHelperTest extends \PHPUnit_Framework_TestCase
 		$this->_locatorHelper->getElementLocator('element-name', '');
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetElementLocator()
 	{
 		$locator = $this->_locatorHelper->getElementLocator('element-name', 'block-name');
@@ -107,11 +78,6 @@ class LocatorHelperTest extends \PHPUnit_Framework_TestCase
 		$this->_assertLocatorClassName($locator, 'block-name__element-name');
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetElementLocatorWithModificator()
 	{
 		$locator = $this->_locatorHelper->getElementLocator(

--- a/tests/aik099/QATools/BEM/PropertyDecorator/BEMPropertyDecoratorTest.php
+++ b/tests/aik099/QATools/BEM/PropertyDecorator/BEMPropertyDecoratorTest.php
@@ -18,11 +18,6 @@ use tests\aik099\QATools\PageObject\PropertyDecorator\DefaultPropertyDecoratorTe
 class BEMPropertyDecoratorTest extends DefaultPropertyDecoratorTest
 {
 
-	/**
-	 * Prepares page.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		$this->locatorClass = '\\aik099\\QATools\\BEM\\ElementLocator\\BEMElementLocator';
@@ -31,11 +26,6 @@ class BEMPropertyDecoratorTest extends DefaultPropertyDecoratorTest
 		parent::setUp();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testBlockProxy()
 	{
 		$element_class = '\\aik099\\QATools\\BEM\\Element\\Block';
@@ -59,11 +49,6 @@ class BEMPropertyDecoratorTest extends DefaultPropertyDecoratorTest
 		$this->assertNotEmpty($proxy->getNodes());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testElementProxy()
 	{
 		$element_class = '\\aik099\\QATools\\BEM\\Element\\Element';
@@ -84,11 +69,6 @@ class BEMPropertyDecoratorTest extends DefaultPropertyDecoratorTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string $part_class BEM part class.
-	 *
-	 * @return void
 	 * @dataProvider bemPartDataProvider
 	 * @expectedException \aik099\QATools\PageObject\Exception\AnnotationException
 	 * @expectedExceptionCode \aik099\QATools\PageObject\Exception\AnnotationException::TYPE_REQUIRED
@@ -100,11 +80,6 @@ class BEMPropertyDecoratorTest extends DefaultPropertyDecoratorTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string $part_class BEM part class.
-	 *
-	 * @return void
 	 * @dataProvider bemPartDataProvider
 	 * @expectedException \aik099\QATools\PageObject\Exception\AnnotationException
 	 * @expectedExceptionCode \aik099\QATools\PageObject\Exception\AnnotationException::TYPE_INCORRECT_USAGE
@@ -117,11 +92,6 @@ class BEMPropertyDecoratorTest extends DefaultPropertyDecoratorTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string $part_class BEM part class.
-	 *
-	 * @return void
 	 * @dataProvider bemPartDataProvider
 	 * @expectedException \aik099\QATools\PageObject\Exception\AnnotationException
 	 * @expectedExceptionCode \aik099\QATools\PageObject\Exception\AnnotationException::TYPE_INCORRECT_USAGE
@@ -149,9 +119,6 @@ class BEMPropertyDecoratorTest extends DefaultPropertyDecoratorTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\PageObject\Exception\AnnotationException
 	 * @expectedExceptionCode \aik099\QATools\PageObject\Exception\AnnotationException::TYPE_INCORRECT_USAGE
 	 */
@@ -168,9 +135,6 @@ class BEMPropertyDecoratorTest extends DefaultPropertyDecoratorTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\PageObject\Exception\AnnotationException
 	 * @expectedExceptionCode \aik099\QATools\PageObject\Exception\AnnotationException::TYPE_INCORRECT_USAGE
 	 */

--- a/tests/aik099/QATools/BEM/Proxy/BlockProxyTest.php
+++ b/tests/aik099/QATools/BEM/Proxy/BlockProxyTest.php
@@ -18,11 +18,6 @@ use tests\aik099\QATools\PageObject\Proxy\AbstractProxyTestCase;
 class BlockProxyTest extends AbstractProxyTestCase
 {
 
-	/**
-	 * Creates proxy.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		$this->ignoreLocatorTests[] = 'testGetName';
@@ -60,11 +55,6 @@ class BlockProxyTest extends AbstractProxyTestCase
 		$this->locator->shouldReceive('findAll')->once()->andReturn(array($this->createNodeElement()));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testDefaultClassName()
 	{
 		$expected = '\\aik099\\QATools\\BEM\\Element\\Block';
@@ -72,11 +62,6 @@ class BlockProxyTest extends AbstractProxyTestCase
 		$this->assertInstanceOf($expected, $this->element->getObject());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetClassName()
 	{
 		$expected = '\\tests\\aik099\\QATools\\BEM\\Fixture\\Element\\BlockChild';
@@ -85,40 +70,22 @@ class BlockProxyTest extends AbstractProxyTestCase
 		$this->assertInstanceOf($expected, $this->element->getObject());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testIsValidSubstitute()
 	{
 		$this->assertInstanceOf('\\aik099\\QATools\\BEM\\Element\\IBlock', $this->element);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetName()
 	{
 		$this->assertEquals('sample-name', $this->element->getName());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testMethodForwardingSuccess()
 	{
 		$this->assertInternalType('array', $this->element->getNodes());
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\PageObject\Exception\ElementNotFoundException
 	 */
 	public function testGetObjectEmptyLocator()

--- a/tests/aik099/QATools/BEM/Proxy/ElementProxyTest.php
+++ b/tests/aik099/QATools/BEM/Proxy/ElementProxyTest.php
@@ -18,11 +18,6 @@ use tests\aik099\QATools\PageObject\Proxy\AbstractProxyTestCase;
 class ElementProxyTest extends AbstractProxyTestCase
 {
 
-	/**
-	 * Creates proxy.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		$this->ignoreLocatorTests[] = 'testGetName';
@@ -36,11 +31,6 @@ class ElementProxyTest extends AbstractProxyTestCase
 		parent::setUp();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testDefaultClassName()
 	{
 		$expected = '\\aik099\\QATools\\BEM\\Element\\Element';
@@ -48,11 +38,6 @@ class ElementProxyTest extends AbstractProxyTestCase
 		$this->assertInstanceOf($expected, $this->element->getObject());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetClassName()
 	{
 		$expected = '\\tests\\aik099\\QATools\\BEM\\Fixture\\Element\\ElementChild';
@@ -61,31 +46,16 @@ class ElementProxyTest extends AbstractProxyTestCase
 		$this->assertInstanceOf($expected, $this->element->getObject());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testIsValidSubstitute()
 	{
 		$this->assertInstanceOf('\\aik099\\QATools\\BEM\\Element\\IElement', $this->element);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetName()
 	{
 		$this->assertEquals('sample-name', $this->element->getName());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testMethodForwardingSuccess()
 	{
 		$this->assertInstanceOf('\\aik099\\QATools\\PageObject\\Element\\IWebElement', $this->element->getWrappedElement());

--- a/tests/aik099/QATools/HtmlElements/Annotation/ElementNameAnnotationTest.php
+++ b/tests/aik099/QATools/HtmlElements/Annotation/ElementNameAnnotationTest.php
@@ -16,11 +16,6 @@ use aik099\QATools\HtmlElements\Annotation\ElementNameAnnotation;
 class ElementNameAnnotationTest extends \PHPUnit_Framework_TestCase
 {
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testInitAnnotation()
 	{
 		$expected = 'test';

--- a/tests/aik099/QATools/HtmlElements/Element/AbstractElementContainerTest.php
+++ b/tests/aik099/QATools/HtmlElements/Element/AbstractElementContainerTest.php
@@ -17,11 +17,6 @@ use Mockery as m;
 class AbstractElementContainerTest extends AbstractTypifiedElementTest
 {
 
-	/**
-	 * Prepares mocks for object creation.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		if ( is_null($this->elementClass) ) {
@@ -50,11 +45,6 @@ class AbstractElementContainerTest extends AbstractTypifiedElementTest
 		$this->pageFactory->shouldReceive('createDecorator')->times($times)->andReturn($decorator);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testFindAll()
 	{
 		$expected = 'C';
@@ -65,11 +55,6 @@ class AbstractElementContainerTest extends AbstractTypifiedElementTest
 		$this->assertSame($expected, $this->typifiedElement->find('A', 'B'));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetPageFactory()
 	{
 		$element = $this->createElement();
@@ -79,11 +64,6 @@ class AbstractElementContainerTest extends AbstractTypifiedElementTest
 		$this->assertSame($this->pageFactory, $method->invoke($element));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testWaitFor()
 	{
 		$web_element = $this->webElement;

--- a/tests/aik099/QATools/HtmlElements/Element/AbstractTypifiedElementTest.php
+++ b/tests/aik099/QATools/HtmlElements/Element/AbstractTypifiedElementTest.php
@@ -42,11 +42,6 @@ class AbstractTypifiedElementTest extends TestCase
 	 */
 	protected $typifiedElement;
 
-	/**
-	 * Prepares mocks for object creation.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		parent::setUp();
@@ -73,21 +68,11 @@ class AbstractTypifiedElementTest extends TestCase
 
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testConstructor()
 	{
 		$this->assertSame($this->webElement, $this->typifiedElement->getWrappedElement());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testFromNodeElement()
 	{
 		$node_element = $this->createNodeElement();
@@ -101,11 +86,6 @@ class AbstractTypifiedElementTest extends TestCase
 		$this->assertEquals($node_element->getXpath(), $element->getXpath());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetName()
 	{
 		$expected = 'OK';
@@ -113,22 +93,12 @@ class AbstractTypifiedElementTest extends TestCase
 		$this->assertEquals($expected, $this->typifiedElement->getName());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetSession()
 	{
 		$this->assertSame($this->session, $this->typifiedElement->getSession());
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string $method_name Method name.
-	 *
-	 * @return void
 	 * @dataProvider simpleMethodDataProvider
 	 */
 	public function testSimpleMethod($method_name)
@@ -139,11 +109,6 @@ class AbstractTypifiedElementTest extends TestCase
 		$this->assertSame($expected, $this->typifiedElement->$method_name());
 	}
 
-	/**
-	 * Provides sample data for simple methods test.
-	 *
-	 * @return array
-	 */
 	public function simpleMethodDataProvider()
 	{
 		return array(
@@ -155,11 +120,6 @@ class AbstractTypifiedElementTest extends TestCase
 		);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testAttribute()
 	{
 		$expected = 'B';
@@ -170,11 +130,6 @@ class AbstractTypifiedElementTest extends TestCase
 		$this->assertSame($expected, $this->typifiedElement->getAttribute('A'));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetContainer()
 	{
 		$container = m::mock('\\aik099\\QATools\\PageObject\\ISearchContext');
@@ -183,11 +138,6 @@ class AbstractTypifiedElementTest extends TestCase
 		$this->assertSame($this->typifiedElement, $this->typifiedElement->setContainer($container));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetContainer()
 	{
 		$expected = 'OK';
@@ -196,11 +146,6 @@ class AbstractTypifiedElementTest extends TestCase
 		$this->assertEquals($expected, $this->typifiedElement->getContainer());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testToString()
 	{
 		$element = $this->createElement();

--- a/tests/aik099/QATools/HtmlElements/Element/ButtonTest.php
+++ b/tests/aik099/QATools/HtmlElements/Element/ButtonTest.php
@@ -16,11 +16,6 @@ use aik099\QATools\HtmlElements\Element\Button;
 class ButtonTest extends AbstractTypifiedElementTest
 {
 
-	/**
-	 * Prepares test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		if ( is_null($this->elementClass) ) {
@@ -30,11 +25,6 @@ class ButtonTest extends AbstractTypifiedElementTest
 		parent::setUp();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testClick()
 	{
 		$this->webElement->shouldReceive('click')->once()->andReturnNull();

--- a/tests/aik099/QATools/HtmlElements/Element/CheckboxTest.php
+++ b/tests/aik099/QATools/HtmlElements/Element/CheckboxTest.php
@@ -17,11 +17,6 @@ use Mockery as m;
 class CheckboxTest extends LabeledElementTest
 {
 
-	/**
-	 * Prepares test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		if ( is_null($this->elementClass) ) {
@@ -32,12 +27,6 @@ class CheckboxTest extends LabeledElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string  $test_method Test method.
-	 * @param boolean $checked     Checked.
-	 *
-	 * @return void
 	 * @dataProvider checkDataProvider
 	 */
 	public function testCheckUncheck($test_method, $checked)
@@ -50,12 +39,6 @@ class CheckboxTest extends LabeledElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string  $test_method Test method.
-	 * @param boolean $checked     Checked.
-	 *
-	 * @return void
 	 * @dataProvider checkDataProvider
 	 */
 	public function testToggle($test_method, $checked)
@@ -68,12 +51,6 @@ class CheckboxTest extends LabeledElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string  $test_method Test method.
-	 * @param boolean $checked     Checked.
-	 *
-	 * @return void
 	 * @dataProvider checkDataProvider
 	 */
 	public function testToggleInvert($test_method, $checked)
@@ -86,11 +63,6 @@ class CheckboxTest extends LabeledElementTest
 		$this->assertEquals('OK', $element->toggle());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testIsChecked()
 	{
 		$this->webElement->shouldReceive('isChecked')->once()->andReturn('OK');
@@ -112,12 +84,6 @@ class CheckboxTest extends LabeledElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param mixed   $value       Input value.
-	 * @param boolean $final_value Final value, that goes to toggle method.
-	 *
-	 * @return void
 	 * @dataProvider setValueDataProvider
 	 */
 	public function testSetValue($value, $final_value)
@@ -129,11 +95,6 @@ class CheckboxTest extends LabeledElementTest
 		$this->assertSame($checkbox, $checkbox->setValue($value));
 	}
 
-	/**
-	 * Test data for "setValue" method testing.
-	 *
-	 * @return array
-	 */
 	public function setValueDataProvider()
 	{
 		return array(

--- a/tests/aik099/QATools/HtmlElements/Element/FileInputTest.php
+++ b/tests/aik099/QATools/HtmlElements/Element/FileInputTest.php
@@ -17,11 +17,6 @@ use Mockery as m;
 class FileInputTest extends AbstractTypifiedElementTest
 {
 
-	/**
-	 * Prepares test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		if ( is_null($this->elementClass) ) {
@@ -32,12 +27,6 @@ class FileInputTest extends AbstractTypifiedElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param mixed   $attribute_value Attribute value.
-	 * @param boolean $multiple        Is multiple.
-	 *
-	 * @return void
 	 * @dataProvider isMultipleDataProvider
 	 */
 	public function testIsMultiple($attribute_value, $multiple)
@@ -47,11 +36,6 @@ class FileInputTest extends AbstractTypifiedElementTest
 		$this->assertSame($multiple, $this->getElement()->isMultiple());
 	}
 
-	/**
-	 * Provides attribute values for "isMultiple" test.
-	 *
-	 * @return array
-	 */
 	public function isMultipleDataProvider()
 	{
 		return array(
@@ -61,9 +45,6 @@ class FileInputTest extends AbstractTypifiedElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\HtmlElements\Exception\FileInputException
 	 * @expectedExceptionCode \aik099\QATools\HtmlElements\Exception\FileInputException::TYPE_FILE_NOT_FOUND
 	 * @expectedExceptionMessage File "/non-existing-file.txt" doesn't exist
@@ -73,11 +54,6 @@ class FileInputTest extends AbstractTypifiedElementTest
 		$this->getElement()->setFileToUpload('/non-existing-file.txt');
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetExistingFileToUpload()
 	{
 		$element = $this->getElement();
@@ -86,11 +62,6 @@ class FileInputTest extends AbstractTypifiedElementTest
 		$this->assertSame($element, $element->setFileToUpload(__FILE__));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetValue()
 	{
 		/* @var $element FileInput */

--- a/tests/aik099/QATools/HtmlElements/Element/FormTest.php
+++ b/tests/aik099/QATools/HtmlElements/Element/FormTest.php
@@ -20,11 +20,6 @@ class FormTest extends AbstractElementContainerTest
 
 	const TYPIFIED_ELEMENT_CLASS = '\\aik099\\QATools\\HtmlElements\\Element\\AbstractTypifiedElement';
 
-	/**
-	 * Prepares test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		if ( is_null($this->elementClass) ) {
@@ -34,11 +29,6 @@ class FormTest extends AbstractElementContainerTest
 		parent::setUp();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testFill()
 	{
 		/** @var Form $form */
@@ -70,9 +60,6 @@ class FormTest extends AbstractElementContainerTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\HtmlElements\Exception\FormException
 	 * @expectedExceptionCode \aik099\QATools\HtmlElements\Exception\FormException::TYPE_NOT_FOUND
 	 * @expectedExceptionMessage Form field "field-name" not found
@@ -90,11 +77,6 @@ class FormTest extends AbstractElementContainerTest
 		$this->getElement()->getNodeElements('field-name');
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetNodeElementsSuccess()
 	{
 		$node_elements = array($this->createNodeElement());
@@ -123,13 +105,6 @@ class FormTest extends AbstractElementContainerTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string $tag_name      Tag name.
-	 * @param string $input_type    Input type.
-	 * @param string $element_class Element class.
-	 *
-	 * @return void
 	 * @dataProvider typifyDataProvider
 	 */
 	public function testTypify($tag_name, $input_type, $element_class)
@@ -148,11 +123,6 @@ class FormTest extends AbstractElementContainerTest
 		$this->assertInstanceOf($element_class, $form_element);
 	}
 
-	/**
-	 * Data provider for "typify" method testing.
-	 *
-	 * @return array
-	 */
 	public function typifyDataProvider()
 	{
 		return array(
@@ -169,9 +139,6 @@ class FormTest extends AbstractElementContainerTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\HtmlElements\Exception\FormException
 	 * @expectedExceptionCode \aik099\QATools\HtmlElements\Exception\FormException::TYPE_UNKNOWN_FIELD
 	 * @expectedExceptionMessage Unable create typified element for element (class: aik099\QATools\PageObject\Element\WebElement; xpath: XPATH)
@@ -185,9 +152,6 @@ class FormTest extends AbstractElementContainerTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\HtmlElements\Exception\FormException
 	 * @expectedExceptionCode \aik099\QATools\HtmlElements\Exception\FormException::TYPE_READONLY_FIELD
 	 * @expectedExceptionMessage Element ELEMENT NAME doesn't support value changing
@@ -200,11 +164,6 @@ class FormTest extends AbstractElementContainerTest
 		$this->getElement()->setValue($typified_element, 'the value');
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetValueSuccess()
 	{
 		$mock_parts = array(
@@ -219,11 +178,6 @@ class FormTest extends AbstractElementContainerTest
 		$this->assertSame($form, $form->setValue($typified_element, 'the value'));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSubmit()
 	{
 		$this->webElement->shouldReceive('submit')->withNoArgs()->once()->andReturnNull();

--- a/tests/aik099/QATools/HtmlElements/Element/LabeledElementTest.php
+++ b/tests/aik099/QATools/HtmlElements/Element/LabeledElementTest.php
@@ -17,11 +17,6 @@ use aik099\QATools\HtmlElements\Element\LabeledElement;
 class LabeledElementTest extends AbstractTypifiedElementTest
 {
 
-	/**
-	 * Prepares test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		if ( is_null($this->elementClass) ) {
@@ -31,11 +26,6 @@ class LabeledElementTest extends AbstractTypifiedElementTest
 		parent::setUp();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetLabelById()
 	{
 		$container = m::mock('\\aik099\\QATools\\PageObject\\ISearchContext');
@@ -53,11 +43,6 @@ class LabeledElementTest extends AbstractTypifiedElementTest
 		$this->assertEquals('FOUND1', $this->getElement()->getLabel());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetParentLabel()
 	{
 		$this->webElement->shouldReceive('getAttribute')->with('id')->once()->andReturnNull();
@@ -66,11 +51,6 @@ class LabeledElementTest extends AbstractTypifiedElementTest
 		$this->assertEquals('FOUND2', $this->getElement()->getLabel());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetFollowingLabel()
 	{
 		$this->webElement
@@ -92,11 +72,6 @@ class LabeledElementTest extends AbstractTypifiedElementTest
 		$this->assertEquals('FOUND3', $this->getElement()->getLabel());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetLabelTextNotFound()
 	{
 		/* @var $element LabeledElement */
@@ -106,11 +81,6 @@ class LabeledElementTest extends AbstractTypifiedElementTest
 		$this->assertNull($element->getLabelText());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetLabelTextFound()
 	{
 		$expected = 'LABEL_TEXT';
@@ -124,11 +94,6 @@ class LabeledElementTest extends AbstractTypifiedElementTest
 		$this->assertEquals($expected, $element->getLabelText());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetText()
 	{
 		$expected = 'OK';

--- a/tests/aik099/QATools/HtmlElements/Element/LinkTest.php
+++ b/tests/aik099/QATools/HtmlElements/Element/LinkTest.php
@@ -16,11 +16,6 @@ use aik099\QATools\HtmlElements\Element\Link;
 class LinkTest extends AbstractTypifiedElementTest
 {
 
-	/**
-	 * Prepares test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		if ( is_null($this->elementClass) ) {
@@ -30,11 +25,6 @@ class LinkTest extends AbstractTypifiedElementTest
 		parent::setUp();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetUrl()
 	{
 		$expected = 'OK';
@@ -43,11 +33,6 @@ class LinkTest extends AbstractTypifiedElementTest
 		$this->assertSame($expected, $this->getElement()->getUrl());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testClick()
 	{
 		$this->webElement->shouldReceive('click')->once()->andReturnNull();
@@ -57,11 +42,6 @@ class LinkTest extends AbstractTypifiedElementTest
 		$this->assertSame($element, $element->click());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetText()
 	{
 		$expected = 'OK';

--- a/tests/aik099/QATools/HtmlElements/Element/RadioGroupTest.php
+++ b/tests/aik099/QATools/HtmlElements/Element/RadioGroupTest.php
@@ -19,11 +19,6 @@ use Mockery\MockInterface;
 class RadioGroupTest extends TypifiedElementCollectionTest
 {
 
-	/**
-	 * Prepares test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		if ( is_null($this->collectionClass) ) {
@@ -50,21 +45,11 @@ class RadioGroupTest extends TypifiedElementCollectionTest
 		return $element;
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testHasSelectedButtonNotFound()
 	{
 		$this->assertFalse($this->mockCollection()->hasSelectedButton());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testHasSelectedButtonFound()
 	{
 		$radio = $this->createRadioButton();
@@ -74,9 +59,6 @@ class RadioGroupTest extends TypifiedElementCollectionTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\HtmlElements\Exception\RadioGroupException
 	 * @expectedExceptionCode \aik099\QATools\HtmlElements\Exception\RadioGroupException::TYPE_NOT_SELECTED
 	 */
@@ -85,11 +67,6 @@ class RadioGroupTest extends TypifiedElementCollectionTest
 		$this->mockCollection()->getSelectedButton();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetSelectedButtonFound()
 	{
 		$radio = $this->createRadioButton();
@@ -99,9 +76,6 @@ class RadioGroupTest extends TypifiedElementCollectionTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\HtmlElements\Exception\RadioGroupException
 	 * @expectedExceptionCode \aik099\QATools\HtmlElements\Exception\RadioGroupException::TYPE_NOT_FOUND
 	 */
@@ -110,11 +84,6 @@ class RadioGroupTest extends TypifiedElementCollectionTest
 		$this->mockCollection()->selectButtonByLabelText('ANY');
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSelectButtonByLabelTextFound()
 	{
 		$radio = $this->createRadioButton();
@@ -126,9 +95,6 @@ class RadioGroupTest extends TypifiedElementCollectionTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\HtmlElements\Exception\RadioGroupException
 	 * @expectedExceptionCode \aik099\QATools\HtmlElements\Exception\RadioGroupException::TYPE_NOT_FOUND
 	 */
@@ -137,11 +103,6 @@ class RadioGroupTest extends TypifiedElementCollectionTest
 		$this->mockCollection()->selectButtonByValue('ANY');
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSelectButtonByValueFound()
 	{
 		$radio = $this->createRadioButton();
@@ -153,9 +114,6 @@ class RadioGroupTest extends TypifiedElementCollectionTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\HtmlElements\Exception\RadioGroupException
 	 * @expectedExceptionCode \aik099\QATools\HtmlElements\Exception\RadioGroupException::TYPE_NOT_FOUND
 	 */
@@ -164,11 +122,6 @@ class RadioGroupTest extends TypifiedElementCollectionTest
 		$this->mockCollection()->selectButtonByIndex(100);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSelectButtonByIndexFound()
 	{
 		$radio = $this->createRadioButton();
@@ -178,11 +131,6 @@ class RadioGroupTest extends TypifiedElementCollectionTest
 		$this->assertSame($element, $element->selectButtonByIndex(0));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetValue()
 	{
 		/* @var $element RadioGroup */

--- a/tests/aik099/QATools/HtmlElements/Element/RadioTest.php
+++ b/tests/aik099/QATools/HtmlElements/Element/RadioTest.php
@@ -17,11 +17,6 @@ use aik099\QATools\HtmlElements\Element\RadioButton;
 class RadioTest extends LabeledElementTest
 {
 
-	/**
-	 * Prepares test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		if ( is_null($this->elementClass) ) {
@@ -31,11 +26,6 @@ class RadioTest extends LabeledElementTest
 		parent::setUp();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSelect()
 	{
 		$this->webElement->shouldReceive('getAttribute')->with('value')->once()->andReturn('OK');
@@ -46,11 +36,6 @@ class RadioTest extends LabeledElementTest
 		$this->assertSame($element, $element->select());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testIsSelected()
 	{
 		$expected = 'OK';

--- a/tests/aik099/QATools/HtmlElements/Element/SelectOptionTest.php
+++ b/tests/aik099/QATools/HtmlElements/Element/SelectOptionTest.php
@@ -27,11 +27,6 @@ class SelectOptionTest extends AbstractTypifiedElementTest
 	 */
 	protected $select;
 
-	/**
-	 * Prepares test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		if ( is_null($this->elementClass) ) {
@@ -44,11 +39,6 @@ class SelectOptionTest extends AbstractTypifiedElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param boolean $checked Checked.
-	 *
-	 * @return void
 	 * @dataProvider selectDeselectDataProvider
 	 */
 	public function testSelect($checked)
@@ -67,9 +57,6 @@ class SelectOptionTest extends AbstractTypifiedElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\HtmlElements\Exception\SelectException
 	 * @expectedExceptionCode \aik099\QATools\HtmlElements\Exception\SelectException::TYPE_UNBOUND_OPTION
 	 * @expectedExceptionMessage No SELECT element association defined
@@ -83,11 +70,6 @@ class SelectOptionTest extends AbstractTypifiedElementTest
 		$option->select();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetSelect()
 	{
 		/** @var SelectOption $option */
@@ -97,12 +79,6 @@ class SelectOptionTest extends AbstractTypifiedElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param boolean $checked      Checked.
-	 * @param string  $driver_class Driver class.
-	 *
-	 * @return void
 	 * @dataProvider selectDeselectDataProvider
 	 */
 	public function testDeselect($checked, $driver_class)
@@ -128,11 +104,6 @@ class SelectOptionTest extends AbstractTypifiedElementTest
 		$this->assertSame($element, $element->deselect());
 	}
 
-	/**
-	 * Data provider for "select/deselect" method test.
-	 *
-	 * @return array
-	 */
 	public function selectDeselectDataProvider()
 	{
 		return array(
@@ -144,12 +115,6 @@ class SelectOptionTest extends AbstractTypifiedElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string  $test_method Typified element method.
-	 * @param boolean $checked     Checked.
-	 *
-	 * @return void
 	 * @dataProvider selectDataProvider
 	 */
 	public function testToggle($test_method, $checked)
@@ -162,12 +127,6 @@ class SelectOptionTest extends AbstractTypifiedElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string  $test_method Typified element method.
-	 * @param boolean $checked     Checked.
-	 *
-	 * @return void
 	 * @dataProvider selectDataProvider
 	 */
 	public function testToggleInvert($test_method, $checked)
@@ -180,11 +139,6 @@ class SelectOptionTest extends AbstractTypifiedElementTest
 		$this->assertEquals('OK', $element->toggle());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testIsSelected()
 	{
 		$this->webElement->shouldReceive('isSelected')->once()->andReturn('OK');
@@ -205,11 +159,6 @@ class SelectOptionTest extends AbstractTypifiedElementTest
 		);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetValue()
 	{
 		$expected = 'OK';
@@ -218,11 +167,6 @@ class SelectOptionTest extends AbstractTypifiedElementTest
 		$this->assertEquals($expected, $this->getElement()->getValue());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetText()
 	{
 		$expected = 'OK';

--- a/tests/aik099/QATools/HtmlElements/Element/SelectTest.php
+++ b/tests/aik099/QATools/HtmlElements/Element/SelectTest.php
@@ -20,11 +20,6 @@ class SelectTest extends AbstractTypifiedElementTest
 
 	const SELECT_OPTION_CLASS = '\\aik099\\QATools\\HtmlElements\\Element\\SelectOption';
 
-	/**
-	 * Prepares test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		if ( is_null($this->elementClass) ) {
@@ -35,12 +30,6 @@ class SelectTest extends AbstractTypifiedElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param mixed   $attribute_value Attribute value.
-	 * @param boolean $multiple        Is multiple.
-	 *
-	 * @return void
 	 * @dataProvider isMultipleDataProvider
 	 */
 	public function testIsMultiple($attribute_value, $multiple)
@@ -50,11 +39,6 @@ class SelectTest extends AbstractTypifiedElementTest
 		$this->assertSame($multiple, $this->getElement()->isMultiple());
 	}
 
-	/**
-	 * Provides attribute values for "isMultiple" test.
-	 *
-	 * @return array
-	 */
 	public function isMultipleDataProvider()
 	{
 		return array(
@@ -63,11 +47,6 @@ class SelectTest extends AbstractTypifiedElementTest
 		);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetOptions()
 	{
 		$this->webElement->shouldReceive('findAll')->with('se', array('tagName' => 'option'))->once()->andReturn(
@@ -77,11 +56,6 @@ class SelectTest extends AbstractTypifiedElementTest
 		$this->assertValidOptions($this->getElement()->getOptions());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetOptionsByValue()
 	{
 		$this->selectorsHandler->shouldReceive('xpathLiteral')->with('SV')->andReturn('SV');
@@ -98,11 +72,6 @@ class SelectTest extends AbstractTypifiedElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param boolean $exact_match Search exactly.
-	 *
-	 * @return void
 	 * @dataProvider trueFalseDataProvider
 	 */
 	public function testGetOptionsByText($exact_match)
@@ -123,11 +92,6 @@ class SelectTest extends AbstractTypifiedElementTest
 		$this->assertValidOptions($this->getElement()->getOptionsByText('SV', $exact_match));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetSelectedOptions()
 	{
 		$selected_option = $this->createOption(true);
@@ -143,11 +107,6 @@ class SelectTest extends AbstractTypifiedElementTest
 		$this->assertSame($selected_option, $options[0]);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetFirstSelectedOptionSuccess()
 	{
 		$selected_option1 = $this->createOption(true);
@@ -165,9 +124,6 @@ class SelectTest extends AbstractTypifiedElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\HtmlElements\Exception\SelectException
 	 * @expectedExceptionCode \aik099\QATools\HtmlElements\Exception\SelectException::TYPE_NOT_SELECTED
 	 */
@@ -181,11 +137,6 @@ class SelectTest extends AbstractTypifiedElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param boolean $is_multiple Select is multiple.
-	 *
-	 * @return void
 	 * @dataProvider trueFalseDataProvider
 	 */
 	public function testSelectByText($is_multiple)
@@ -199,9 +150,6 @@ class SelectTest extends AbstractTypifiedElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\HtmlElements\Exception\SelectException
 	 * @expectedExceptionCode \aik099\QATools\HtmlElements\Exception\SelectException::TYPE_NOT_FOUND
 	 */
@@ -214,11 +162,6 @@ class SelectTest extends AbstractTypifiedElementTest
 		$this->assertSame($element, $element->selectByText('TX'));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testDeselectByText()
 	{
 		$selected_option = $this->createOption(true);
@@ -232,11 +175,6 @@ class SelectTest extends AbstractTypifiedElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param boolean $is_multiple Select is multiple.
-	 *
-	 * @return void
 	 * @dataProvider trueFalseDataProvider
 	 */
 	public function testSelectByValue($is_multiple)
@@ -250,9 +188,6 @@ class SelectTest extends AbstractTypifiedElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\HtmlElements\Exception\SelectException
 	 * @expectedExceptionCode \aik099\QATools\HtmlElements\Exception\SelectException::TYPE_NOT_FOUND
 	 */
@@ -265,11 +200,6 @@ class SelectTest extends AbstractTypifiedElementTest
 		$this->assertSame($element, $element->selectByValue('TX'));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testDeselectByValue()
 	{
 		$selected_option = $this->createOption(true);
@@ -303,11 +233,6 @@ class SelectTest extends AbstractTypifiedElementTest
 		return array($option1, $option2);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSelectAll()
 	{
 		/* @var $element Select */
@@ -319,9 +244,6 @@ class SelectTest extends AbstractTypifiedElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\HtmlElements\Exception\SelectException
 	 * @expectedExceptionCode \aik099\QATools\HtmlElements\Exception\SelectException::TYPE_NOT_MULTISELECT
 	 */
@@ -334,11 +256,6 @@ class SelectTest extends AbstractTypifiedElementTest
 		$this->assertSame($element, $element->selectAll());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetSelected()
 	{
 		/* @var $element Select */
@@ -356,9 +273,6 @@ class SelectTest extends AbstractTypifiedElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\HtmlElements\Exception\SelectException
 	 * @expectedExceptionCode \aik099\QATools\HtmlElements\Exception\SelectException::TYPE_NOT_MULTISELECT
 	 */
@@ -371,11 +285,6 @@ class SelectTest extends AbstractTypifiedElementTest
 		$this->assertSame($element, $element->setSelected(array()));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testDeselectAll()
 	{
 		$selected_option = $this->createOption(true);
@@ -390,9 +299,6 @@ class SelectTest extends AbstractTypifiedElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\HtmlElements\Exception\SelectException
 	 * @expectedExceptionCode \aik099\QATools\HtmlElements\Exception\SelectException::TYPE_NOT_MULTISELECT
 	 */
@@ -406,13 +312,6 @@ class SelectTest extends AbstractTypifiedElementTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param mixed  $value         Value to set.
-	 * @param mixed  $final_value   Values, that goes to internal methods.
-	 * @param string $setter_method Setter method.
-	 *
-	 * @return void
 	 * @dataProvider setValueDataProvider
 	 */
 	public function testSetValue($value, $final_value, $setter_method)
@@ -424,11 +323,6 @@ class SelectTest extends AbstractTypifiedElementTest
 		$this->assertSame($element, $element->setValue($value));
 	}
 
-	/**
-	 * Provides test data for "setValue" method testing.
-	 *
-	 * @return array
-	 */
 	public function setValueDataProvider()
 	{
 		return array(
@@ -483,11 +377,6 @@ class SelectTest extends AbstractTypifiedElementTest
 		$this->assertEquals('XPATH', $options[0]->getXpath());
 	}
 
-	/**
-	 * Provides test data for boolean arguments.
-	 *
-	 * @return array
-	 */
 	public function trueFalseDataProvider()
 	{
 		return array(

--- a/tests/aik099/QATools/HtmlElements/Element/TextBlockTest.php
+++ b/tests/aik099/QATools/HtmlElements/Element/TextBlockTest.php
@@ -17,11 +17,6 @@ use aik099\QATools\HtmlElements\Element\TextBlock;
 class TextBlockTest extends AbstractTypifiedElementTest
 {
 
-	/**
-	 * Prepares test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		if ( is_null($this->elementClass) ) {
@@ -31,11 +26,6 @@ class TextBlockTest extends AbstractTypifiedElementTest
 		parent::setUp();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetText()
 	{
 		$expected = 'OK';

--- a/tests/aik099/QATools/HtmlElements/Element/TextInputTest.php
+++ b/tests/aik099/QATools/HtmlElements/Element/TextInputTest.php
@@ -17,11 +17,6 @@ use aik099\QATools\HtmlElements\Element\TextInput;
 class TextInputTest extends AbstractTypifiedElementTest
 {
 
-	/**
-	 * Prepares test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		if ( is_null($this->elementClass) ) {
@@ -31,11 +26,6 @@ class TextInputTest extends AbstractTypifiedElementTest
 		parent::setUp();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testClear()
 	{
 		$this->webElement->shouldReceive('setValue')->with('')->once()->andReturnNull();
@@ -45,11 +35,6 @@ class TextInputTest extends AbstractTypifiedElementTest
 		$this->assertEquals($element, $element->clear());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSendKeys()
 	{
 		$expected = 'OK';
@@ -60,11 +45,6 @@ class TextInputTest extends AbstractTypifiedElementTest
 		$this->assertEquals($element, $element->sendKeys($expected));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetText()
 	{
 		$expected = 'OK';
@@ -73,11 +53,6 @@ class TextInputTest extends AbstractTypifiedElementTest
 		$this->assertEquals($expected, $this->getElement()->getText());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetValue()
 	{
 		/* @var $element TextInput */

--- a/tests/aik099/QATools/HtmlElements/Element/TypifiedElementCollectionTest.php
+++ b/tests/aik099/QATools/HtmlElements/Element/TypifiedElementCollectionTest.php
@@ -28,11 +28,6 @@ class TypifiedElementCollectionTest extends AbstractElementCollectionTestCase
 	 */
 	protected $webElement;
 
-	/**
-	 * Prepares mocks for object creation.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		if ( is_null($this->collectionClass) ) {
@@ -46,11 +41,6 @@ class TypifiedElementCollectionTest extends AbstractElementCollectionTestCase
 		parent::setUp();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetName()
 	{
 		$expected = 'OK';
@@ -58,11 +48,6 @@ class TypifiedElementCollectionTest extends AbstractElementCollectionTestCase
 		$this->assertEquals($expected, $this->element->getName());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetContainer()
 	{
 		$container = m::mock('\\aik099\\QATools\\PageObject\\ISearchContext');
@@ -70,11 +55,6 @@ class TypifiedElementCollectionTest extends AbstractElementCollectionTestCase
 		$this->assertSame($this->element, $this->element->setContainer($container));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetContainer()
 	{
 		$container = m::mock('\\aik099\\QATools\\PageObject\\ISearchContext');
@@ -94,6 +74,5 @@ class TypifiedElementCollectionTest extends AbstractElementCollectionTestCase
 
 class DummyTypifiedElementCollection extends AbstractTypifiedElementCollection
 {
-
 
 }

--- a/tests/aik099/QATools/HtmlElements/PropertyDecorator/TypifiedPropertyDecoratorTest.php
+++ b/tests/aik099/QATools/HtmlElements/PropertyDecorator/TypifiedPropertyDecoratorTest.php
@@ -18,11 +18,6 @@ use tests\aik099\QATools\PageObject\PropertyDecorator\DefaultPropertyDecoratorTe
 class TypifiedPropertyDecoratorTest extends DefaultPropertyDecoratorTest
 {
 
-	/**
-	 * Prepares page.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		$this->decoratorClass = '\\aik099\\QATools\\HtmlElements\\PropertyDecorator\\TypifiedPropertyDecorator';
@@ -31,11 +26,6 @@ class TypifiedPropertyDecoratorTest extends DefaultPropertyDecoratorTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string $element_class Element class.
-	 * @param string $proxy_class   Proxy class.
-	 *
 	 * @return WebElementProxy
 	 * @dataProvider proxyDataProvider
 	 */
@@ -54,11 +44,6 @@ class TypifiedPropertyDecoratorTest extends DefaultPropertyDecoratorTest
 		return $proxy;
 	}
 
-	/**
-	 * Provide test data for proxy.
-	 *
-	 * @return array
-	 */
 	public function proxyDataProvider()
 	{
 		$data = parent::proxyDataProvider();

--- a/tests/aik099/QATools/HtmlElements/Proxy/ElementContainerProxyTest.php
+++ b/tests/aik099/QATools/HtmlElements/Proxy/ElementContainerProxyTest.php
@@ -35,11 +35,6 @@ class ElementContainerProxyTest extends TypifiedElementProxyTest
 		$this->pageFactory->shouldReceive('initElements')->andReturn($this->pageFactory);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetPageFactory()
 	{
 		$object = $this->element->getObject();
@@ -50,11 +45,6 @@ class ElementContainerProxyTest extends TypifiedElementProxyTest
 		$this->assertSame($this->pageFactory, $method->invoke($object));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testDefaultClassName()
 	{
 		$this->assertInstanceOf(self::ELEMENT_CLASS, $this->element->getObject());

--- a/tests/aik099/QATools/HtmlElements/Proxy/TypifiedElementCollectionProxyTest.php
+++ b/tests/aik099/QATools/HtmlElements/Proxy/TypifiedElementCollectionProxyTest.php
@@ -19,21 +19,11 @@ class TypifiedElementCollectionProxyTest extends TypifiedElementProxyTest
 
 	const ELEMENT_CLASS = '\\tests\\aik099\\QATools\\HtmlElements\\Fixture\\Element\\TypifiedElementCollectionChild';
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testDefaultClassName()
 	{
 		$this->assertInstanceOf(self::ELEMENT_CLASS, $this->element->getObject());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testMethodForwardingSuccess()
 	{
 		$this->assertEquals(1, $this->element->proxyMe());

--- a/tests/aik099/QATools/HtmlElements/Proxy/TypifiedElementProxyTest.php
+++ b/tests/aik099/QATools/HtmlElements/Proxy/TypifiedElementProxyTest.php
@@ -18,11 +18,6 @@ use tests\aik099\QATools\PageObject\Proxy\AbstractProxyTestCase;
 class TypifiedElementProxyTest extends AbstractProxyTestCase
 {
 
-	/**
-	 * Creates proxy.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		$this->ignoreLocatorTests[] = 'testGetName';
@@ -35,11 +30,6 @@ class TypifiedElementProxyTest extends AbstractProxyTestCase
 		parent::setUp();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testDefaultClassName()
 	{
 		$expected = '\\aik099\\QATools\\HtmlElements\\Element\\TextBlock';
@@ -47,11 +37,6 @@ class TypifiedElementProxyTest extends AbstractProxyTestCase
 		$this->assertInstanceOf($expected, $this->element->getObject());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetClassName()
 	{
 		$expected = '\\tests\\aik099\\QATools\\HtmlElements\\Fixture\\Element\\ButtonChild';
@@ -60,31 +45,16 @@ class TypifiedElementProxyTest extends AbstractProxyTestCase
 		$this->assertInstanceOf($expected, $this->element->getObject());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testIsValidSubstitute()
 	{
 		$this->assertInstanceOf('\\aik099\\QATools\\HtmlElements\\Element\\ITypifiedElement', $this->element);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetName()
 	{
 		$this->assertEquals('sample-name', $this->element->getName());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetName()
 	{
 		$expected = 'OK';

--- a/tests/aik099/QATools/HtmlElements/TypifiedPageFactoryTest.php
+++ b/tests/aik099/QATools/HtmlElements/TypifiedPageFactoryTest.php
@@ -24,11 +24,6 @@ class TypifiedPageFactoryTest extends PageFactoryTest
 	 */
 	protected $typifiedProperty;
 
-	/**
-	 * Prepares test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		$this->factoryClass = '\\aik099\\QATools\\HtmlElements\\TypifiedPageFactory';

--- a/tests/aik099/QATools/HtmlElementsLive/Element/FormTest.php
+++ b/tests/aik099/QATools/HtmlElementsLive/Element/FormTest.php
@@ -16,11 +16,6 @@ use aik099\QATools\HtmlElements\Element\Form;
 class FormTest extends TypifiedElementTestCase
 {
 
-	/**
-	 * Prepares test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		parent::setUp();
@@ -28,11 +23,6 @@ class FormTest extends TypifiedElementTestCase
 		$this->elementClass = '\\aik099\\QATools\\HtmlElements\\Element\\Form';
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testWaitFor()
 	{
 		$page = $this->session->getPage();

--- a/tests/aik099/QATools/HtmlElementsLive/Element/LabeledElementTest.php
+++ b/tests/aik099/QATools/HtmlElementsLive/Element/LabeledElementTest.php
@@ -16,11 +16,6 @@ use aik099\QATools\HtmlElements\Element\LabeledElement;
 class LabeledElementTest extends TypifiedElementTestCase
 {
 
-	/**
-	 * Prepares test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		parent::setUp();
@@ -29,12 +24,6 @@ class LabeledElementTest extends TypifiedElementTestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string $id         Element ID.
-	 * @param string $label_text Label text.
-	 *
-	 * @return void
 	 * @dataProvider labelDataProvider
 	 */
 	public function testGetLabel($id, $label_text)
@@ -52,12 +41,6 @@ class LabeledElementTest extends TypifiedElementTestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string $id         Element ID.
-	 * @param string $label_text Label text.
-	 *
-	 * @return void
 	 * @dataProvider labelDataProvider
 	 */
 	public function testGetLabelText($id, $label_text)
@@ -68,12 +51,6 @@ class LabeledElementTest extends TypifiedElementTestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string $id         Element ID.
-	 * @param string $label_text Label text.
-	 *
-	 * @return void
 	 * @dataProvider labelDataProvider
 	 */
 	public function testGetText($id, $label_text)

--- a/tests/aik099/QATools/HtmlElementsLive/Element/RadioGroupTest.php
+++ b/tests/aik099/QATools/HtmlElementsLive/Element/RadioGroupTest.php
@@ -18,11 +18,6 @@ class RadioGroupTest extends TypifiedElementTestCase
 
 	const RADIO_CLASS = '\\aik099\\QATools\\HtmlElements\\Element\\RadioButton';
 
-	/**
-	 * Prepares test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		parent::setUp();
@@ -30,11 +25,6 @@ class RadioGroupTest extends TypifiedElementTestCase
 		$this->elementClass = '\\aik099\\QATools\\HtmlElements\\Element\\RadioGroup';
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetButtonsWithName()
 	{
 		/* @var $radio_group RadioGroup */
@@ -45,11 +35,6 @@ class RadioGroupTest extends TypifiedElementTestCase
 		$this->assertInstanceOf(self::RADIO_CLASS, $buttons[0]);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetButtonsWithoutName()
 	{
 		/* @var $radio_group RadioGroup */
@@ -62,11 +47,6 @@ class RadioGroupTest extends TypifiedElementTestCase
 		$this->assertInstanceOf(self::RADIO_CLASS, $buttons[0]);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSelection()
 	{
 		/* @var $radio_group RadioGroup */

--- a/tests/aik099/QATools/HtmlElementsLive/Element/SelectTest.php
+++ b/tests/aik099/QATools/HtmlElementsLive/Element/SelectTest.php
@@ -18,11 +18,6 @@ class SelectTest extends TypifiedElementTestCase
 
 	const SELECT_OPTION_CLASS = '\\aik099\\QATools\\HtmlElements\\Element\\SelectOption';
 
-	/**
-	 * Prepares test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		parent::setUp();
@@ -30,11 +25,6 @@ class SelectTest extends TypifiedElementTestCase
 		$this->elementClass = '\\aik099\\QATools\\HtmlElements\\Element\\Select';
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetOptions()
 	{
 		/* @var $element Select */
@@ -46,11 +36,6 @@ class SelectTest extends TypifiedElementTestCase
 		$this->assertEquals('t1', $options[0]->getText());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetOptionsByValue()
 	{
 		/* @var $element Select */
@@ -62,11 +47,6 @@ class SelectTest extends TypifiedElementTestCase
 		$this->assertEquals('v1', $options[0]->getValue());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetOptionsByText()
 	{
 		/* @var $element Select */
@@ -78,11 +58,6 @@ class SelectTest extends TypifiedElementTestCase
 		$this->assertEquals('t1', $options[0]->getText());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSelectByText()
 	{
 		/* @var $element Select */

--- a/tests/aik099/QATools/HtmlElementsLive/Element/TextInputTest.php
+++ b/tests/aik099/QATools/HtmlElementsLive/Element/TextInputTest.php
@@ -16,11 +16,6 @@ use aik099\QATools\HtmlElements\Element\TextInput;
 class TextInputTest extends TypifiedElementTestCase
 {
 
-	/**
-	 * Prepares test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		parent::setUp();
@@ -29,12 +24,6 @@ class TextInputTest extends TypifiedElementTestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string $element_id    Element ID.
-	 * @param string $expected_text Expected text.
-	 *
-	 * @return void
 	 * @dataProvider sendKeysDataProvider
 	 */
 	public function testSendKeys($element_id, $expected_text)
@@ -47,11 +36,6 @@ class TextInputTest extends TypifiedElementTestCase
 		$this->assertEquals($expected_text, $element->getText());
 	}
 
-	/**
-	 * Test data for "sendKeys" method.
-	 *
-	 * @return array
-	 */
 	public function sendKeysDataProvider()
 	{
 		return array(

--- a/tests/aik099/QATools/HtmlElementsLive/Element/TypifiedElementTestCase.php
+++ b/tests/aik099/QATools/HtmlElementsLive/Element/TypifiedElementTestCase.php
@@ -70,11 +70,6 @@ class TypifiedElementTestCase extends \PHPUnit_Framework_TestCase
 		}
 	}
 
-	/**
-	 * Prepares test.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		parent::setUp();

--- a/tests/aik099/QATools/PageObject/Annotation/FindByAnnotationTest.php
+++ b/tests/aik099/QATools/PageObject/Annotation/FindByAnnotationTest.php
@@ -17,11 +17,6 @@ class FindByAnnotationTest extends \PHPUnit_Framework_TestCase
 {
 
 	/**
-	 * Test description.
-	 *
-	 * @param string $property_name Property name.
-	 *
-	 * @return void
 	 * @dataProvider selectorDataProvider
 	 */
 	public function testDirectSelector($property_name)
@@ -33,11 +28,6 @@ class FindByAnnotationTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string $property_name Property name.
-	 *
-	 * @return void
 	 * @dataProvider selectorDataProvider
 	 */
 	public function testHowAndUsingSelector($property_name)
@@ -69,9 +59,6 @@ class FindByAnnotationTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\PageObject\Exception\AnnotationException
 	 * @expectedExceptionCode \aik099\QATools\PageObject\Exception\AnnotationException::TYPE_INCORRECT_USAGE
 	 */
@@ -82,9 +69,6 @@ class FindByAnnotationTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\PageObject\Exception\AnnotationException
 	 * @expectedExceptionCode \aik099\QATools\PageObject\Exception\AnnotationException::TYPE_INCORRECT_USAGE
 	 */

--- a/tests/aik099/QATools/PageObject/Annotation/PageUrlAnnotationTest.php
+++ b/tests/aik099/QATools/PageObject/Annotation/PageUrlAnnotationTest.php
@@ -17,14 +17,6 @@ class PageUrlAnnotationTest extends \PHPUnit_Framework_TestCase
 {
 
 	/**
-	 * Test description.
-	 *
-	 * @param array  $annotation_params Params for initing the annotation.
-	 * @param string $expected_url      The url which is expected.
-	 * @param array  $expected_params   The expected GET params.
-	 *
-	 * @return void
-	 *
 	 * @dataProvider initAnnotationDataProvider
 	 */
 	public function testInitAnnotation(array $annotation_params, $expected_url, array $expected_params)
@@ -36,11 +28,6 @@ class PageUrlAnnotationTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals($expected_params, $annotation->params);
 	}
 
-	/**
-	 * Data provider for testInitAnnotation.
-	 *
-	 * @return array
-	 */
 	public function initAnnotationDataProvider()
 	{
 		return array(

--- a/tests/aik099/QATools/PageObject/Annotation/TimeoutAnnotationTest.php
+++ b/tests/aik099/QATools/PageObject/Annotation/TimeoutAnnotationTest.php
@@ -16,11 +16,6 @@ use aik099\QATools\PageObject\Annotation\TimeoutAnnotation;
 class TimeoutAnnotationTest extends \PHPUnit_Framework_TestCase
 {
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testInitAnnotation()
 	{
 		$expected = 'test';

--- a/tests/aik099/QATools/PageObject/Element/AbstractElementCollectionTestCase.php
+++ b/tests/aik099/QATools/PageObject/Element/AbstractElementCollectionTestCase.php
@@ -40,11 +40,6 @@ abstract class AbstractElementCollectionTestCase extends TestCase
 	 */
 	protected $element;
 
-	/**
-	 * Prepares mocks for object creation.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		parent::setUp();
@@ -64,11 +59,6 @@ abstract class AbstractElementCollectionTestCase extends TestCase
 
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testArrayAccessInterface()
 	{
 		$element = $this->createValidElementMock();
@@ -87,9 +77,6 @@ abstract class AbstractElementCollectionTestCase extends TestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @depends testArrayAccessInterface
 	 */
 	public function testIteratorInterface()

--- a/tests/aik099/QATools/PageObject/Element/AbstractElementContainerTest.php
+++ b/tests/aik099/QATools/PageObject/Element/AbstractElementContainerTest.php
@@ -17,11 +17,6 @@ use tests\aik099\QATools\PageObject\Fixture\Element\ElementContainerChild;
 class AbstractElementContainerTest extends WebElementTest
 {
 
-	/**
-	 * Prepares mocks for object creation.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		parent::setUp();
@@ -34,11 +29,6 @@ class AbstractElementContainerTest extends WebElementTest
 		$this->pageFactory->shouldReceive('createDecorator')->once()->andReturn($decorator);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetPageFactory()
 	{
 		$element = $this->createElement();

--- a/tests/aik099/QATools/PageObject/Element/WebElementCollectionTest.php
+++ b/tests/aik099/QATools/PageObject/Element/WebElementCollectionTest.php
@@ -18,11 +18,6 @@ use tests\aik099\QATools\PageObject\Element\AbstractElementCollectionTestCase;
 class WebElementCollectionTest extends AbstractElementCollectionTestCase
 {
 
-	/**
-	 * Prepares mocks for object creation.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		if ( is_null($this->collectionClass) ) {
@@ -33,11 +28,6 @@ class WebElementCollectionTest extends AbstractElementCollectionTestCase
 		parent::setUp();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetContainer()
 	{
 		$container = m::mock('\\aik099\\QATools\\PageObject\\ISearchContext');
@@ -45,11 +35,6 @@ class WebElementCollectionTest extends AbstractElementCollectionTestCase
 		$this->assertSame($this->element, $this->element->setContainer($container));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetContainer()
 	{
 		$container = m::mock('\\aik099\\QATools\\PageObject\\ISearchContext');

--- a/tests/aik099/QATools/PageObject/Element/WebElementTest.php
+++ b/tests/aik099/QATools/PageObject/Element/WebElementTest.php
@@ -25,11 +25,6 @@ class WebElementTest extends TestCase
 	 */
 	protected $elementClass = '\\aik099\\QATools\\PageObject\\Element\\WebElement';
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testConstructor()
 	{
 		$element = $this->createElement();
@@ -38,11 +33,6 @@ class WebElementTest extends TestCase
 		$this->assertSame($this->session, $element->getSession());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testFromNodeElement()
 	{
 		/* @var $element_class WebElement */
@@ -56,11 +46,6 @@ class WebElementTest extends TestCase
 		$this->assertEquals($node_element->getXpath(), $element->getXpath());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetContainer()
 	{
 		$element = $this->createElement();
@@ -70,11 +55,6 @@ class WebElementTest extends TestCase
 		$this->assertSame($container, $element->getContainer());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetContainerFallback()
 	{
 		$expected = 'OK';
@@ -84,11 +64,6 @@ class WebElementTest extends TestCase
 		$this->assertEquals($expected, $element->getContainer());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testToString()
 	{
 		$element = $this->createElement();

--- a/tests/aik099/QATools/PageObject/ElementLocator/DefaultElementLocatorFactoryTest.php
+++ b/tests/aik099/QATools/PageObject/ElementLocator/DefaultElementLocatorFactoryTest.php
@@ -26,11 +26,6 @@ class DefaultElementLocatorFactoryTest extends \PHPUnit_Framework_TestCase
 	 */
 	protected $locatorClass = '\\aik099\\QATools\\PageObject\\ElementLocator\\WaitingElementLocator';
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testCreateLocator()
 	{
 		$annotation_manager = m::mock('\\mindplay\\annotations\\AnnotationManager');

--- a/tests/aik099/QATools/PageObject/ElementLocator/DefaultElementLocatorTest.php
+++ b/tests/aik099/QATools/PageObject/ElementLocator/DefaultElementLocatorTest.php
@@ -65,11 +65,6 @@ class DefaultElementLocatorTest extends \PHPUnit_Framework_TestCase
 	 */
 	protected $locator;
 
-	/**
-	 * Prepares page.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		parent::setUp();
@@ -81,21 +76,11 @@ class DefaultElementLocatorTest extends \PHPUnit_Framework_TestCase
 		$this->locator = $this->createLocator();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetSearchContext()
 	{
 		$this->assertSame($this->searchContext, $this->locator->getSearchContext());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testFindOne()
 	{
 		$locator = $this->createLocator(array('findAll'));
@@ -104,11 +89,6 @@ class DefaultElementLocatorTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals('OK', $locator->find());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testFindNone()
 	{
 		$locator = $this->createLocator(array('findAll'));
@@ -117,11 +97,6 @@ class DefaultElementLocatorTest extends \PHPUnit_Framework_TestCase
 		$this->assertNull($locator->find());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetSelectorSuccess()
 	{
 		$expected = array('xpath' => 'xpath1');
@@ -132,9 +107,6 @@ class DefaultElementLocatorTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\PageObject\Exception\AnnotationException
 	 * @expectedExceptionCode \aik099\QATools\PageObject\Exception\AnnotationException::TYPE_REQUIRED
 	 */
@@ -147,11 +119,6 @@ class DefaultElementLocatorTest extends \PHPUnit_Framework_TestCase
 		$this->assertCount(0, $this->locator->findAll());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testToString()
 	{
 		$expected = 'OK';

--- a/tests/aik099/QATools/PageObject/ElementLocator/WaitingElementLocatorTest.php
+++ b/tests/aik099/QATools/PageObject/ElementLocator/WaitingElementLocatorTest.php
@@ -20,11 +20,6 @@ class WaitingElementLocatorTest extends DefaultElementLocatorTest
 
 	const TIMEOUT = 5000;
 
-	/**
-	 * Prepares page.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		$this->locatorClass = '\\aik099\\QATools\\PageObject\\ElementLocator\\WaitingElementLocator';
@@ -32,11 +27,6 @@ class WaitingElementLocatorTest extends DefaultElementLocatorTest
 		parent::setUp();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetSelectorSuccessWithTimeout()
 	{
 		$search_context = $this->searchContext;
@@ -61,9 +51,6 @@ class WaitingElementLocatorTest extends DefaultElementLocatorTest
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\PageObject\Exception\AnnotationException
 	 * @expectedExceptionCode \aik099\QATools\PageObject\Exception\AnnotationException::TYPE_REQUIRED
 	 */

--- a/tests/aik099/QATools/PageObject/PageFactoryTest.php
+++ b/tests/aik099/QATools/PageObject/PageFactoryTest.php
@@ -71,11 +71,6 @@ class PageFactoryTest extends TestCase
 	 */
 	protected $urlBuilderFactory;
 
-	/**
-	 * Prepare factory.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		parent::setUp();
@@ -93,33 +88,18 @@ class PageFactoryTest extends TestCase
 		$this->realFactory = $this->createFactory();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testConstructorWithAnnotationManager()
 	{
 		$this->assertSame($this->session, $this->realFactory->getSession());
 		$this->assertSame($this->annotationManager, $this->realFactory->getAnnotationManager());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testConstructorWithoutAnnotationManager()
 	{
 		$factory = $this->createFactory(false);
 		$this->assertInstanceOf(self::ANNOTATION_MANAGER_CLASS, $factory->getAnnotationManager());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetAnnotationManager()
 	{
 		$annotation_manager = m::mock(self::ANNOTATION_MANAGER_CLASS);
@@ -127,11 +107,6 @@ class PageFactoryTest extends TestCase
 		$this->assertSame($annotation_manager, $this->realFactory->getAnnotationManager());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testCreateDecorator()
 	{
 		$this->assertInstanceOf($this->decoratorClass, $this->createDefaultDecorator());
@@ -149,22 +124,12 @@ class PageFactoryTest extends TestCase
 		return $this->createFactory()->createDecorator($search_context);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testAnnotationRegistry()
 	{
 		$this->assertArrayHasKey('find-by', $this->annotationManager->registry);
 		$this->assertArrayHasKey('page-url', $this->annotationManager->registry);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testInitElementsChaining()
 	{
 		$decorator = $this->createNullDecorator();
@@ -174,14 +139,6 @@ class PageFactoryTest extends TestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string|null $url             Url.
-	 * @param array       $params          Get params.
-	 * @param boolean     $use_url_builder Should setUrlBuilder called.
-	 *
-	 * @return void
-	 *
 	 * @dataProvider initPageDataProvider
 	 */
 	public function testInitPage($url, array $params, $use_url_builder)
@@ -247,22 +204,12 @@ class PageFactoryTest extends TestCase
 		);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testInitElementContainer()
 	{
 		$element_container = m::mock('\\aik099\\QATools\\PageObject\\Element\\AbstractElementContainer');
 		$this->assertSame($this->realFactory, $this->realFactory->initElementContainer($element_container));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testProxyFields()
 	{
 		$this->annotationManager->shouldReceive('getClassAnnotations')->andReturn(array());
@@ -279,11 +226,6 @@ class PageFactoryTest extends TestCase
 		$this->assertEquals('OK', $page->elementWithUse);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetPage()
 	{
 		$factory = $this->createFactory(true, array('initPage', 'initElements', 'createDecorator'));
@@ -295,11 +237,6 @@ class PageFactoryTest extends TestCase
 		$this->assertInstanceOf($this->pageClass, $page);
 	}
 
-	/**
-	 * Tests getUrlBuilderFactory and setUrlBuilderFactory.
-	 *
-	 * @return void
-	 */
 	public function testGetUrlBuilderFactory()
 	{
 		/* @var IUrlBuilderFactory $url_builder_factory */

--- a/tests/aik099/QATools/PageObject/PageTest.php
+++ b/tests/aik099/QATools/PageObject/PageTest.php
@@ -50,11 +50,6 @@ class PageTest extends TestCase
 	 */
 	protected $urlBuilderFactory;
 
-	/**
-	 * Prepares page.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		parent::setUp();
@@ -70,21 +65,11 @@ class PageTest extends TestCase
 		$this->page = new $this->pageClass($this->pageFactory);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testConstructor()
 	{
 		$this->assertSame($this->session, $this->page->getSession());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetAbsoluteUrl()
 	{
 		$expected = 'RL';
@@ -95,11 +80,6 @@ class PageTest extends TestCase
 		$this->assertEquals($expected, $this->page->getAbsoluteUrl());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testOpenCorrect()
 	{
 		$expected = 'RL';
@@ -113,9 +93,6 @@ class PageTest extends TestCase
 	}
 
 	/**
-	 * Test with an url builder that returns no url.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\PageObject\Exception\PageException
 	 * @expectedExceptionCode \aik099\QATools\PageObject\Exception\PageException::TYPE_EMPTY_URL
 	 */
@@ -129,9 +106,6 @@ class PageTest extends TestCase
 	}
 
 	/**
-	 * Test open with missing url builder.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\PageObject\Exception\PageException
 	 * @expectedExceptionCode \aik099\QATools\PageObject\Exception\PageException::TYPE_MISSING_URL_BUILDER
 	 */
@@ -141,13 +115,7 @@ class PageTest extends TestCase
 	}
 
 	/**
-	 * Tests if params are correctly added to the URL.
-	 *
-	 * @param string $expected The expected merged url.
-	 * @param array  $params   The GET params.
-	 *
 	 * @dataProvider getAbsoluteUrlWithParamsDataProvider
-	 * @return void
 	 */
 	public function testGetAbsoluteUrlWithParams($expected, array $params)
 	{
@@ -160,11 +128,6 @@ class PageTest extends TestCase
 		$this->assertEquals($expected, $this->page->getAbsoluteUrl($params));
 	}
 
-	/**
-	 * Data Provider for the GET param test.
-	 *
-	 * @return array
-	 */
 	public function getAbsoluteUrlWithParamsDataProvider()
 	{
 		return array(
@@ -179,11 +142,6 @@ class PageTest extends TestCase
 		);
 	}
 
-	/**
-	 * Test that open is still working if params are passed.
-	 *
-	 * @return void
-	 */
 	public function testOpenWithParamsCorrect()
 	{
 		$url = 'RL';

--- a/tests/aik099/QATools/PageObject/PropertyDecorator/DefaultPropertyDecoratorTest.php
+++ b/tests/aik099/QATools/PageObject/PropertyDecorator/DefaultPropertyDecoratorTest.php
@@ -66,11 +66,6 @@ class DefaultPropertyDecoratorTest extends TestCase
 	 */
 	protected $decorator;
 
-	/**
-	 * Prepares page.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		parent::setUp();
@@ -89,11 +84,6 @@ class DefaultPropertyDecoratorTest extends TestCase
 		$this->decorator = new $this->decoratorClass($this->locatorFactory, $this->pageFactory);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testEmptyLocatorPreventsDecoration()
 	{
 		$this->property->shouldReceive('isSimpleDataType')->andReturn(false);
@@ -103,12 +93,6 @@ class DefaultPropertyDecoratorTest extends TestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string  $data_type           Data type.
-	 * @param boolean $is_simple_data_type Is data type simple.
-	 *
-	 * @return void
 	 * @dataProvider decorationAbortingDataProvider
 	 */
 	public function testDecorationAborting($data_type, $is_simple_data_type)
@@ -134,9 +118,6 @@ class DefaultPropertyDecoratorTest extends TestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\PageObject\Exception\PageFactoryException
 	 * @expectedExceptionCode \aik099\QATools\PageObject\Exception\PageFactoryException::TYPE_UNKNOWN_CLASS
 	 */
@@ -149,11 +130,6 @@ class DefaultPropertyDecoratorTest extends TestCase
 		$this->decorator->decorate($this->property);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testUnknownProxyClassPreventsDecoration()
 	{
 		$this->property->shouldReceive('getDataType')->andReturn(__CLASS__);
@@ -163,11 +139,6 @@ class DefaultPropertyDecoratorTest extends TestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string $element_class Element class.
-	 * @param string $proxy_class   Proxy class.
-	 *
 	 * @return WebElementProxy
 	 * @dataProvider proxyDataProvider
 	 */
@@ -206,11 +177,6 @@ class DefaultPropertyDecoratorTest extends TestCase
 		$this->assertSame($proxy_container, $proxy->getContainer());
 	}
 
-	/**
-	 * Provide test data for proxy.
-	 *
-	 * @return array
-	 */
 	public function proxyDataProvider()
 	{
 		return array(

--- a/tests/aik099/QATools/PageObject/PropertyTest.php
+++ b/tests/aik099/QATools/PageObject/PropertyTest.php
@@ -41,11 +41,6 @@ class PropertyTest extends \PHPUnit_Framework_TestCase
 	 */
 	protected $annotationManager;
 
-	/**
-	 * Prepares page.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		parent::setUp();
@@ -56,11 +51,6 @@ class PropertyTest extends \PHPUnit_Framework_TestCase
 		$this->property = new $this->propertyClass($property, $this->annotationManager);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testConstructor()
 	{
 		$reflection_property = new \ReflectionProperty($this, 'propertyClass');
@@ -71,12 +61,6 @@ class PropertyTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string $data_type Data type.
-	 * @param mixed  $result    Result.
-	 *
-	 * @return void
 	 * @dataProvider getDataTypeDataProvider
 	 */
 	public function testGetDataType($data_type, $result)
@@ -109,11 +93,6 @@ class PropertyTest extends \PHPUnit_Framework_TestCase
 		);
 	}
 
-	/**
-	 * Test data provider for getDataType.
-	 *
-	 * @return array
-	 */
 	public function getDataTypeDataProvider()
 	{
 		return array(
@@ -124,12 +103,6 @@ class PropertyTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string $data_type Data type.
-	 * @param mixed  $result    Result.
-	 *
-	 * @return void
 	 * @dataProvider getRawDataTypeDataProvider
 	 */
 	public function testGetRawDataType($data_type, $result)
@@ -139,11 +112,6 @@ class PropertyTest extends \PHPUnit_Framework_TestCase
 		$this->assertSame($result, $this->property->getRawDataType());
 	}
 
-	/**
-	 * Test data provider for getDataType.
-	 *
-	 * @return array
-	 */
 	public function getRawDataTypeDataProvider()
 	{
 		return array(
@@ -154,12 +122,6 @@ class PropertyTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string  $data_type Data type.
-	 * @param boolean $is_simple Is data type simple.
-	 *
-	 * @return void
 	 * @dataProvider dataTypeProvider
 	 */
 	public function testIsSimpleDataType($data_type, $is_simple)
@@ -173,11 +135,6 @@ class PropertyTest extends \PHPUnit_Framework_TestCase
 		$this->assertSame($is_simple, $property->isSimpleDataType());
 	}
 
-	/**
-	 * Provides data types for test.
-	 *
-	 * @return array
-	 */
 	public function dataTypeProvider()
 	{
 		return array(
@@ -195,12 +152,6 @@ class PropertyTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @param string  $data_type Data type.
-	 * @param boolean $is_array  Is data type an array.
-	 *
-	 * @return void
 	 * @dataProvider isDataTypeArrayProvider
 	 */
 	public function testIsDataTypeArray($data_type, $is_array)
@@ -210,11 +161,6 @@ class PropertyTest extends \PHPUnit_Framework_TestCase
 		$this->assertSame($is_array, $this->property->isDataTypeArray());
 	}
 
-	/**
-	 * Provides data types for test.
-	 *
-	 * @return array
-	 */
 	public function isDataTypeArrayProvider()
 	{
 		return array(
@@ -224,11 +170,6 @@ class PropertyTest extends \PHPUnit_Framework_TestCase
 		);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetAnnotations()
 	{
 		$expected = 'OK';
@@ -241,11 +182,6 @@ class PropertyTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $this->property->getAnnotations('A'));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetAnnotationsFromPropertyOrClass()
 	{
 		$expected = 'OK';
@@ -258,11 +194,6 @@ class PropertyTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $this->property->getAnnotationsFromPropertyOrClass('A'));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetAnnotationsFromPropertyOrClassFallback()
 	{
 		$var_annotation = new VarAnnotation();
@@ -290,11 +221,6 @@ class PropertyTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $this->property->getAnnotationsFromPropertyOrClass('A'));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testToString()
 	{
 		$this->assertEquals(get_class($this) . '::propertyClass', (string)$this->property);

--- a/tests/aik099/QATools/PageObject/Proxy/AbstractProxyTestCase.php
+++ b/tests/aik099/QATools/PageObject/Proxy/AbstractProxyTestCase.php
@@ -50,11 +50,6 @@ abstract class AbstractProxyTestCase extends AbstractElementCollectionTestCase
 		'testSetName', 'testArrayAccessInterface', 'testIteratorInterface', 'testFromNodeElements',
 	);
 
-	/**
-	 * Creates proxy.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		if ( is_null($this->collectionClass) ) {
@@ -88,20 +83,12 @@ abstract class AbstractProxyTestCase extends AbstractElementCollectionTestCase
 		$this->locator->shouldReceive('findAll')->once()->andReturn(array($this->createNodeElement()));
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetObjectSharing()
 	{
 		$this->assertSame($this->element->getObject(), $this->element->getObject());
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\PageObject\Exception\ElementNotFoundException
 	 */
 	public function testGetObjectEmptyLocator()
@@ -112,20 +99,12 @@ abstract class AbstractProxyTestCase extends AbstractElementCollectionTestCase
 		$this->createElement()->getObject();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testMethodForwardingSuccess()
 	{
 		$this->assertEquals('XPATH', $this->element->getXpath());
 	}
 
 	/**
-	 * Test description.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\PageObject\Exception\ElementException
 	 * @expectedExceptionCode \aik099\QATools\PageObject\Exception\ElementException::TYPE_UNKNOWN_METHOD
 	 */
@@ -134,11 +113,6 @@ abstract class AbstractProxyTestCase extends AbstractElementCollectionTestCase
 		$this->element->nonExistingMethod();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetContainer()
 	{
 		$container = m::mock('\\aik099\\QATools\\PageObject\\ISearchContext');
@@ -147,21 +121,11 @@ abstract class AbstractProxyTestCase extends AbstractElementCollectionTestCase
 		$this->assertSame($container, $this->element->getContainer());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetContainerFallback()
 	{
 		$this->assertNull($this->element->getContainer());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testContainerToElement()
 	{
 		$container = m::mock('\\aik099\\QATools\\PageObject\\ISearchContext');
@@ -170,25 +134,10 @@ abstract class AbstractProxyTestCase extends AbstractElementCollectionTestCase
 		$this->assertSame($container, $this->element->getObject()->getContainer());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	abstract public function testDefaultClassName();
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	abstract public function testSetClassName();
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	abstract public function testIsValidSubstitute();
 
 	/**

--- a/tests/aik099/QATools/PageObject/Proxy/ElementContainerProxyTest.php
+++ b/tests/aik099/QATools/PageObject/Proxy/ElementContainerProxyTest.php
@@ -35,21 +35,11 @@ class ElementContainerProxyTest extends WebElementProxyTest
 		$this->pageFactory->shouldReceive('initElements')->andReturn($this->pageFactory);
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testDefaultClassName()
 	{
 		$this->assertInstanceOf(self::ELEMENT_CLASS, $this->element->getObject());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testGetPageFactory()
 	{
 		$object = $this->element->getObject();

--- a/tests/aik099/QATools/PageObject/Proxy/WebElementCollectionProxyTest.php
+++ b/tests/aik099/QATools/PageObject/Proxy/WebElementCollectionProxyTest.php
@@ -17,11 +17,6 @@ use Mockery as m;
 class WebElementCollectionProxyTest extends WebElementProxyTest
 {
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testDefaultClassName()
 	{
 		$expected = '\\aik099\\QATools\\PageObject\\Element\\WebElementCollection';
@@ -29,11 +24,6 @@ class WebElementCollectionProxyTest extends WebElementProxyTest
 		$this->assertInstanceOf($expected, $this->element->getObject());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testMethodForwardingSuccess()
 	{
 		$this->assertEquals(1, $this->element->proxyMe());

--- a/tests/aik099/QATools/PageObject/Proxy/WebElementProxyTest.php
+++ b/tests/aik099/QATools/PageObject/Proxy/WebElementProxyTest.php
@@ -16,11 +16,6 @@ use Mockery as m;
 class WebElementProxyTest extends AbstractProxyTestCase
 {
 
-	/**
-	 * Creates proxy.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		if ( is_null($this->collectionClass) ) {
@@ -31,11 +26,6 @@ class WebElementProxyTest extends AbstractProxyTestCase
 		parent::setUp();
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testDefaultClassName()
 	{
 		$expected = '\\aik099\\QATools\\PageObject\\Element\\WebElement';
@@ -43,11 +33,6 @@ class WebElementProxyTest extends AbstractProxyTestCase
 		$this->assertInstanceOf($expected, $this->element->getObject());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testSetClassName()
 	{
 		$expected = '\\aik099\\QATools\\PageObject\\Element\\WebElement';
@@ -56,11 +41,6 @@ class WebElementProxyTest extends AbstractProxyTestCase
 		$this->assertInstanceOf($expected, $this->element->getObject());
 	}
 
-	/**
-	 * Test description.
-	 *
-	 * @return void
-	 */
 	public function testIsValidSubstitute()
 	{
 		$this->assertInstanceOf('\\aik099\\QATools\\PageObject\\Element\\IWebElement', $this->element);

--- a/tests/aik099/QATools/PageObject/SeleniumSelectorTest.php
+++ b/tests/aik099/QATools/PageObject/SeleniumSelectorTest.php
@@ -25,11 +25,6 @@ class SeleniumSelectorTest extends \PHPUnit_Framework_TestCase
 	 */
 	protected $selector;
 
-	/**
-	 * Sets up a Selenium Selector fixture.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		$selectors_handler = new SelectorsHandler();
@@ -38,11 +33,6 @@ class SeleniumSelectorTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Testing not implemented selectors.
-	 *
-	 * @param array $locator Locator.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\PageObject\Exception\ElementException
 	 * @expectedExceptionCode \aik099\QATools\PageObject\Exception\ElementException::TYPE_UNKNOWN_SELECTOR
 	 * @dataProvider notImplementedDataProvider
@@ -52,11 +42,6 @@ class SeleniumSelectorTest extends \PHPUnit_Framework_TestCase
 		$this->selector->translateToXPath($locator);
 	}
 
-	/**
-	 * Returns locators, that are not yet implemented.
-	 *
-	 * @return array
-	 */
 	public function notImplementedDataProvider()
 	{
 		return array(
@@ -75,10 +60,6 @@ class SeleniumSelectorTest extends \PHPUnit_Framework_TestCase
 	/**
 	 * Testing logic, behind locator into xpath transformation.
 	 *
-	 * @param array  $locator        Locator.
-	 * @param string $expected_xpath Expected xpath.
-	 *
-	 * @return void
 	 * @dataProvider correctDataProvider
 	 */
 	public function testCorrect(array $locator, $expected_xpath)
@@ -124,9 +105,6 @@ class SeleniumSelectorTest extends \PHPUnit_Framework_TestCase
 	/**
 	 * Testing incorrect locators.
 	 *
-	 * @param mixed $locator Locator.
-	 *
-	 * @return void
 	 * @expectedException \aik099\QATools\PageObject\Exception\ElementException
 	 * @expectedExceptionCode \aik099\QATools\PageObject\Exception\ElementException::TYPE_INCORRECT_SELECTOR
 	 * @dataProvider incorrectDataProvider

--- a/tests/aik099/QATools/PageObject/Url/UrlBuilderFactoryTest.php
+++ b/tests/aik099/QATools/PageObject/Url/UrlBuilderFactoryTest.php
@@ -55,11 +55,6 @@ class UrlBuilderFactoryTest extends TestCase
 		$this->assertEquals($expected_anchor, $url_builder->getAnchor());
 	}
 
-	/**
-	 * Provides data for testing testGetUrlBuilder.
-	 *
-	 * @return array
-	 */
 	public function getUrlBuilderDataProvider()
 	{
 		return array(

--- a/tests/aik099/QATools/PageObject/Url/UrlBuilderTest.php
+++ b/tests/aik099/QATools/PageObject/Url/UrlBuilderTest.php
@@ -19,16 +19,6 @@ class UrlBuilderTest extends TestCase
 {
 
 	/**
-	 * Test the constructor.
-	 *
-	 * @param string $url             The url.
-	 * @param array  $params          The GET params.
-	 * @param string $expected_path   The resulting expected path.
-	 * @param array  $expected_params The resulting expected GET params.
-	 * @param string $expected_anchor The resulting expected anchor.
-	 *
-	 * @return void
-	 *
 	 * @dataProvider constructorDataProvider
 	 */
 	public function testConstructor($url, array $params, $expected_path, array $expected_params, $expected_anchor)
@@ -40,11 +30,6 @@ class UrlBuilderTest extends TestCase
 		$this->assertEquals($url_builder->getAnchor(), $expected_anchor);
 	}
 
-	/**
-	 * Data provider for testConstructor.
-	 *
-	 * @return array
-	 */
 	public function constructorDataProvider()
 	{
 		return array(
@@ -125,8 +110,6 @@ class UrlBuilderTest extends TestCase
 	/**
 	 * Test the constructor with empty url.
 	 *
-	 * @return void
-	 *
 	 * @expectedException \aik099\QATools\PageObject\Exception\UrlBuilderException
 	 * @expectedExceptionCode \aik099\QATools\PageObject\Exception\UrlBuilderException::TYPE_EMPTY_PATH
 	 */
@@ -136,14 +119,6 @@ class UrlBuilderTest extends TestCase
 	}
 
 	/**
-	 * Test the build.
-	 *
-	 * @param string $url          The url.
-	 * @param array  $params       The GET params.
-	 * @param string $expected_url The resulting expected url.
-	 *
-	 * @return void
-	 *
 	 * @dataProvider buildDataProvider
 	 */
 	public function testBuild($url, array $params, $expected_url)
@@ -154,11 +129,6 @@ class UrlBuilderTest extends TestCase
 		$this->assertSame($actual_url, $expected_url);
 	}
 
-	/**
-	 * Data provider for testBuild.
-	 *
-	 * @return array
-	 */
 	public function buildDataProvider()
 	{
 		return array(

--- a/tests/aik099/QATools/TestCase.php
+++ b/tests/aik099/QATools/TestCase.php
@@ -46,11 +46,6 @@ class TestCase extends \PHPUnit_Framework_TestCase
 	 */
 	protected $pageFactory;
 
-	/**
-	 * Prepares page factory.
-	 *
-	 * @return void
-	 */
 	protected function setUp()
 	{
 		parent::setUp();


### PR DESCRIPTION
When I just started to use PHP_CodeSniffer I wasn't aware how to make PHPDoc's of functions/methods non-required in some files (e.g. tests), so I created "Live Template" in PhpStorm to create them for me.

This decision without doubt increased test suite size. With https://github.com/aik099/CodingStandard/commit/10da2eea4b5ce0289500f6c2c3c44e4652f7068d commit this is not a problem and we can safely remove not needed comments.
