### PR TITLE
Support for absolute urls and config base_url in UrlBuilderFactory

### DIFF
--- a/library/aik099/QATools/PageObject/Exception/UrlBuilderException.php
+++ b/library/aik099/QATools/PageObject/Exception/UrlBuilderException.php
@@ -19,4 +19,6 @@ class UrlBuilderException extends PageFactoryException
 
 	const TYPE_EMPTY_PATH = 101;
 
+	const TYPE_MISSING_BASE_URL = 102;
+
 }

--- a/library/aik099/QATools/PageObject/PageFactory.php
+++ b/library/aik099/QATools/PageObject/PageFactory.php
@@ -195,9 +195,17 @@ class PageFactory implements IPageFactory
 		/* @var $annotations PageUrlAnnotation[] */
 		$annotations = $this->annotationManager->getClassAnnotations($page, '@page-url');
 
-		if ( $annotations ) {
-			$page->setUrlBuilder($this->urlBuilderFactory->getUrlBuilder($annotations[0]->url, $annotations[0]->params));
+		if ( empty($annotations) ) {
+			return $this;
 		}
+
+		$page->setUrlBuilder(
+			$this->urlBuilderFactory->getUrlBuilder(
+				$annotations[0]->url,
+				$annotations[0]->params,
+				$this->config->getOption('base_url')
+			)
+		);
 
 		return $this;
 	}

--- a/library/aik099/QATools/PageObject/Url/IUrlBuilderFactory.php
+++ b/library/aik099/QATools/PageObject/Url/IUrlBuilderFactory.php
@@ -22,11 +22,12 @@ interface IUrlBuilderFactory
 	/**
 	 * Returns an instance of a class implementing IUrlBuilder interface based on given arguments.
 	 *
-	 * @param string $path   The path of the URL after the domain.
-	 * @param array  $params Additional GET params as an array.
+	 * @param string $path     The path of the URL after the domain.
+	 * @param array  $params   Additional GET params as an array.
+	 * @param string $base_url The base url of the url builder.
 	 *
 	 * @return IUrlBuilder
 	 */
-	public function getUrlBuilder($path, array $params = array());
+	public function getUrlBuilder($path, array $params = array(), $base_url = '');
 
 }

--- a/library/aik099/QATools/PageObject/Url/UrlBuilderFactory.php
+++ b/library/aik099/QATools/PageObject/Url/UrlBuilderFactory.php
@@ -22,14 +22,15 @@ class UrlBuilderFactory implements IUrlBuilderFactory
 	/**
 	 * Returns an instance of a class implementing IUrlBuilder interface based on given arguments.
 	 *
-	 * @param string $path   The url/path.
-	 * @param array  $params The additional GET params.
+	 * @param string $path     The url/path.
+	 * @param array  $params   The additional GET params.
+	 * @param string $base_url The base url of the url builder.
 	 *
 	 * @return IUrlBuilder
 	 */
-	public function getUrlBuilder($path, array $params = array())
+	public function getUrlBuilder($path, array $params = array(), $base_url = '')
 	{
-		return new UrlBuilder($path, $params);
+		return new UrlBuilder($path, $params, $base_url);
 	}
 
 }

--- a/library/aik099/QATools/PageObject/Url/UrlParser.php
+++ b/library/aik099/QATools/PageObject/Url/UrlParser.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * This file is part of the qa-tools library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/aik099/qa-tools
+ */
+
+namespace aik099\QATools\PageObject\Url;
+
+
+use Mockery\Expectation;
+
+/**
+ * Parses url and returns components.
+ *
+ * @method Expectation shouldReceive
+ */
+class UrlParser
+{
+
+	/**
+	 * The url components.
+	 *
+	 * @var array
+	 */
+	protected $components = array();
+
+	/**
+	 * Constructor for UrlParser.
+	 *
+	 * @param string $url The url to parse.
+	 */
+	public function __construct($url)
+	{
+		$this->components = parse_url($url);
+	}
+
+	/**
+	 * Get url component.
+	 *
+	 * @param string $name    The name of the component.
+	 * @param string $default The default value.
+	 *
+	 * @return string
+	 */
+	public function getComponent($name, $default = '')
+	{
+		return !empty($this->components[$name]) ? $this->components[$name] : $default;
+	}
+
+	/**
+	 * Get parsed query.
+	 *
+	 * @return array
+	 */
+	public function getParams()
+	{
+		$result = array();
+		$query = $this->getComponent('query');
+
+		if ( $query ) {
+			parse_str($query, $result);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Merge both url parsers.
+	 *
+	 * @param UrlParser $url_parser The url parser to merge.
+	 *
+	 * @return $this
+	 */
+	public function merge(UrlParser $url_parser)
+	{
+		$this->components = array_merge($this->components, $url_parser->components);
+
+		return $this;
+	}
+
+}

--- a/tests/aik099/QATools/PageObject/PageFactoryTest.php
+++ b/tests/aik099/QATools/PageObject/PageFactoryTest.php
@@ -92,7 +92,7 @@ class PageFactoryTest extends TestCase
 
 		$this->annotationManager = m::mock(self::ANNOTATION_MANAGER_CLASS);
 		$this->urlBuilderFactory = m::mock(self::URL_BUILDER_FACTORY_INTERFACE);
-		$this->config = new Config();
+		$this->config = new Config(array('base_url' => 'http://domain.tld'));
 
 		$this->realFactory = $this->createFactory();
 	}
@@ -161,7 +161,7 @@ class PageFactoryTest extends TestCase
 		$this->realFactory->setUrlBuilderFactory($this->urlBuilderFactory);
 		$this->urlBuilderFactory
 			->shouldReceive('getUrlBuilder')
-			->with($url, $params)
+			->with($url, $params, 'http://domain.tld')
 			->times(isset($url) ? 1 : 0)
 			->andReturn($urlBuilder);
 

--- a/tests/aik099/QATools/PageObject/PageTest.php
+++ b/tests/aik099/QATools/PageObject/PageTest.php
@@ -144,7 +144,7 @@ class PageTest extends TestCase
 
 	public function testOpenWithParamsCorrect()
 	{
-		$url = 'RL';
+		$url = 'http://domain.tld/RL';
 		$expected = $url . '?param=value';
 		$params = array('param' => 'value');
 		/* @var IUrlBuilderFactory $url_builder_factory */

--- a/tests/aik099/QATools/PageObject/Url/UrlBuilderFactoryTest.php
+++ b/tests/aik099/QATools/PageObject/Url/UrlBuilderFactoryTest.php
@@ -29,27 +29,28 @@ class UrlBuilderFactoryTest extends TestCase
 	const URL_BUILDER_INTERFACE = '\\aik099\\QATools\\PageObject\\Url\\IUrlBuilder';
 
 	/**
-	 * Test the factory instantiated class.
-	 *
-	 * @param string $url             The url.
-	 * @param array  $params          GET params.
-	 * @param string $expected_path   The expected path in the builder.
-	 * @param array  $expected_params The expected params in the builder.
-	 * @param string $expected_anchor The expected anchor in the builder.
-	 *
-	 * @return void
-	 *
 	 * @dataProvider getUrlBuilderDataProvider
 	 */
-	public function testGetUrlBuilder($url, array $params, $expected_path, array $expected_params, $expected_anchor)
+	public function testGetUrlBuilder(
+		$url,
+		array $params,
+		$base_url,
+		$expected_protocol,
+		$expected_host,
+		$expected_path,
+		array $expected_params,
+		$expected_anchor
+	)
 	{
 		$factory = new UrlBuilderFactory();
 
 		/* @var UrlBuilder $url_builder */
-		$url_builder = $factory->getUrlBuilder($url, $params);
+		$url_builder = $factory->getUrlBuilder($url, $params, $base_url);
 
 		$this->assertInstanceOf(self::URL_BUILDER_INTERFACE, $url_builder);
 
+		$this->assertEquals($expected_protocol, $url_builder->getProtocol());
+		$this->assertEquals($expected_host, $url_builder->getHost());
 		$this->assertEquals($expected_path, $url_builder->getPath());
 		$this->assertEquals($expected_params, $url_builder->getParams());
 		$this->assertEquals($expected_anchor, $url_builder->getAnchor());
@@ -58,12 +59,66 @@ class UrlBuilderFactoryTest extends TestCase
 	public function getUrlBuilderDataProvider()
 	{
 		return array(
-			array('/path', array(), '/path', array(), ''),
-			array('/path?param=value', array(), '/path', array('param' => 'value'), ''),
-			array('/path', array('param' => 'value'), '/path', array('param' => 'value'), ''),
-			array('/path#anchor', array(), '/path', array(), 'anchor'),
-			array('/path?param=value#anchor', array(), '/path', array('param' => 'value'), 'anchor'),
-			array('/path#anchor', array('param' => 'value'), '/path', array('param' => 'value'), 'anchor'),
+			array(
+				'/path',
+				array(),
+				'http://domain.tld',
+				'http',
+				'domain.tld',
+				'/path',
+				array(),
+				'',
+			),
+			array(
+				'/path?param=value',
+				array(),
+				'http://domain.tld',
+				'http',
+				'domain.tld',
+				'/path',
+				array('param' => 'value'),
+				'',
+			),
+			array(
+				'/path',
+				array('param' => 'value'),
+				'http://domain.tld',
+				'http',
+				'domain.tld',
+				'/path',
+				array('param' => 'value'),
+				'',
+			),
+			array(
+				'/path#anchor',
+				array(),
+				'http://domain.tld',
+				'http',
+				'domain.tld',
+				'/path',
+				array(),
+				'anchor',
+			),
+			array(
+				'/path?param=value#anchor',
+				array(),
+				'http://domain.tld',
+				'http',
+				'domain.tld',
+				'/path',
+				array('param' => 'value'),
+				'anchor',
+			),
+			array(
+				'/path#anchor',
+				array('param' => 'value'),
+				'http://domain.tld',
+				'http',
+				'domain.tld',
+				'/path',
+				array('param' => 'value'),
+				'anchor',
+			),
 		);
 	}
 

--- a/tests/aik099/QATools/PageObject/Url/UrlBuilderTest.php
+++ b/tests/aik099/QATools/PageObject/Url/UrlBuilderTest.php
@@ -21,10 +21,21 @@ class UrlBuilderTest extends TestCase
 	/**
 	 * @dataProvider constructorDataProvider
 	 */
-	public function testConstructor($url, array $params, $expected_path, array $expected_params, $expected_anchor)
+	public function testConstructor(
+		$url,
+		array $params,
+		$base_url,
+		$expected_protocol,
+		$expected_host,
+		$expected_path,
+		array $expected_params,
+		$expected_anchor
+	)
 	{
-		$url_builder = new UrlBuilder($url, $params);
+		$url_builder = new UrlBuilder($url, $params, $base_url);
 
+		$this->assertEquals($url_builder->getProtocol(), $expected_protocol);
+		$this->assertEquals($url_builder->getHost(), $expected_host);
 		$this->assertEquals($url_builder->getPath(), $expected_path);
 		$this->assertEquals($url_builder->getParams(), $expected_params);
 		$this->assertEquals($url_builder->getAnchor(), $expected_anchor);
@@ -36,6 +47,9 @@ class UrlBuilderTest extends TestCase
 			array(
 				'/path',
 				array(),
+				'http://domain.tld',
+				'http',
+				'domain.tld',
 				'/path',
 				array(),
 				'',
@@ -43,6 +57,9 @@ class UrlBuilderTest extends TestCase
 			array(
 				'/path',
 				array('param' => 'value'),
+				'http://domain.tld',
+				'http',
+				'domain.tld',
 				'/path',
 				array('param' => 'value'),
 				'',
@@ -50,6 +67,9 @@ class UrlBuilderTest extends TestCase
 			array(
 				'/path?param=value',
 				array(),
+				'http://domain.tld',
+				'http',
+				'domain.tld',
 				'/path',
 				array('param' => 'value'),
 				'',
@@ -57,6 +77,9 @@ class UrlBuilderTest extends TestCase
 			array(
 				'/path?param1=value1',
 				array('param2' => 'value2'),
+				'http://domain.tld',
+				'http',
+				'domain.tld',
 				'/path',
 				array('param1' => 'value1', 'param2' => 'value2'),
 				'',
@@ -64,6 +87,9 @@ class UrlBuilderTest extends TestCase
 			array(
 				'/path?param=value1',
 				array('param' => 'value2'),
+				'http://domain.tld',
+				'http',
+				'domain.tld',
 				'/path',
 				array('param' => 'value2'),
 				'',
@@ -71,6 +97,9 @@ class UrlBuilderTest extends TestCase
 			array(
 				'/path#anchor',
 				array(),
+				'http://domain.tld',
+				'http',
+				'domain.tld',
 				'/path',
 				array(),
 				'anchor',
@@ -79,6 +108,9 @@ class UrlBuilderTest extends TestCase
 			array(
 				'/path#anchor',
 				array('param' => 'value'),
+				'http://domain.tld',
+				'http',
+				'domain.tld',
 				'/path',
 				array('param' => 'value'),
 				'anchor',
@@ -86,6 +118,9 @@ class UrlBuilderTest extends TestCase
 			array(
 				'/path?param=value#anchor',
 				array(),
+				'http://domain.tld',
+				'http',
+				'domain.tld',
 				'/path',
 				array('param' => 'value'),
 				'anchor',
@@ -93,6 +128,9 @@ class UrlBuilderTest extends TestCase
 			array(
 				'/path?param1=value1#anchor',
 				array('param2' => 'value2'),
+				'http://domain.tld',
+				'http',
+				'domain.tld',
 				'/path',
 				array('param1' => 'value1', 'param2' => 'value2'),
 				'anchor',
@@ -100,6 +138,213 @@ class UrlBuilderTest extends TestCase
 			array(
 				'/path?param=value1#anchor',
 				array('param' => 'value2'),
+				'http://domain.tld',
+				'http',
+				'domain.tld',
+				'/path',
+				array('param' => 'value2'),
+				'anchor',
+			),
+			// Absolute url.
+			array(
+				'http://domain.tld/path',
+				array(),
+				'',
+				'http',
+				'domain.tld',
+				'/path',
+				array(),
+				'',
+			),
+			array(
+				'http://domain.tld/path',
+				array('param' => 'value'),
+				'',
+				'http',
+				'domain.tld',
+				'/path',
+				array('param' => 'value'),
+				'',
+			),
+			array(
+				'http://domain.tld/path?param=value',
+				array(),
+				'',
+				'http',
+				'domain.tld',
+				'/path',
+				array('param' => 'value'),
+				'',
+			),
+			array(
+				'http://domain.tld/path?param1=value1',
+				array('param2' => 'value2'),
+				'',
+				'http',
+				'domain.tld',
+				'/path',
+				array('param1' => 'value1', 'param2' => 'value2'),
+				'',
+			),
+			array(
+				'http://domain.tld/path?param=value1',
+				array('param' => 'value2'),
+				'',
+				'http',
+				'domain.tld',
+				'/path',
+				array('param' => 'value2'),
+				'',
+			),
+			array(
+				'http://domain.tld/path#anchor',
+				array(),
+				'',
+				'http',
+				'domain.tld',
+				'/path',
+				array(),
+				'anchor',
+				'anchor',
+			),
+			array(
+				'http://domain.tld/path#anchor',
+				array('param' => 'value'),
+				'',
+				'http',
+				'domain.tld',
+				'/path',
+				array('param' => 'value'),
+				'anchor',
+			),
+			array(
+				'http://domain.tld/path?param=value#anchor',
+				array(),
+				'',
+				'http',
+				'domain.tld',
+				'/path',
+				array('param' => 'value'),
+				'anchor',
+			),
+			array(
+				'http://domain.tld/path?param1=value1#anchor',
+				array('param2' => 'value2'),
+				'',
+				'http',
+				'domain.tld',
+				'/path',
+				array('param1' => 'value1', 'param2' => 'value2'),
+				'anchor',
+			),
+			array(
+				'http://domain.tld/path?param=value1#anchor',
+				array('param' => 'value2'),
+				'',
+				'http',
+				'domain.tld',
+				'/path',
+				array('param' => 'value2'),
+				'anchor',
+			),
+			// Absolute url and base url.
+			array(
+				'http://domain.tld/path',
+				array(),
+				'http://base.tld',
+				'http',
+				'domain.tld',
+				'/path',
+				array(),
+				'',
+			),
+			array(
+				'http://domain.tld/path',
+				array('param' => 'value'),
+				'http://base.tld',
+				'http',
+				'domain.tld',
+				'/path',
+				array('param' => 'value'),
+				'',
+			),
+			array(
+				'http://domain.tld/path?param=value',
+				array(),
+				'http://base.tld',
+				'http',
+				'domain.tld',
+				'/path',
+				array('param' => 'value'),
+				'',
+			),
+			array(
+				'http://domain.tld/path?param1=value1',
+				array('param2' => 'value2'),
+				'http://base.tld',
+				'http',
+				'domain.tld',
+				'/path',
+				array('param1' => 'value1', 'param2' => 'value2'),
+				'',
+			),
+			array(
+				'http://domain.tld/path?param=value1',
+				array('param' => 'value2'),
+				'http://base.tld',
+				'http',
+				'domain.tld',
+				'/path',
+				array('param' => 'value2'),
+				'',
+			),
+			array(
+				'http://domain.tld/path#anchor',
+				array(),
+				'http://base.tld',
+				'http',
+				'domain.tld',
+				'/path',
+				array(),
+				'anchor',
+				'anchor',
+			),
+			array(
+				'http://domain.tld/path#anchor',
+				array('param' => 'value'),
+				'http://base.tld',
+				'http',
+				'domain.tld',
+				'/path',
+				array('param' => 'value'),
+				'anchor',
+			),
+			array(
+				'http://domain.tld/path?param=value#anchor',
+				array(),
+				'http://base.tld',
+				'http',
+				'domain.tld',
+				'/path',
+				array('param' => 'value'),
+				'anchor',
+			),
+			array(
+				'http://domain.tld/path?param1=value1#anchor',
+				array('param2' => 'value2'),
+				'http://base.tld',
+				'http',
+				'domain.tld',
+				'/path',
+				array('param1' => 'value1', 'param2' => 'value2'),
+				'anchor',
+			),
+			array(
+				'http://domain.tld/path?param=value1#anchor',
+				array('param' => 'value2'),
+				'http://base.tld',
+				'http',
+				'domain.tld',
 				'/path',
 				array('param' => 'value2'),
 				'anchor',
@@ -108,14 +353,21 @@ class UrlBuilderTest extends TestCase
 	}
 
 	/**
-	 * Test the constructor with empty url.
-	 *
 	 * @expectedException \aik099\QATools\PageObject\Exception\UrlBuilderException
 	 * @expectedExceptionCode \aik099\QATools\PageObject\Exception\UrlBuilderException::TYPE_EMPTY_PATH
 	 */
-	public function testConstructorIncorrect()
+	public function testConstructorEmptyPath()
 	{
-		new UrlBuilder('');
+		new UrlBuilder('http://domain.tld');
+	}
+
+	/**
+	 * @expectedException \aik099\QATools\PageObject\Exception\UrlBuilderException
+	 * @expectedExceptionCode \aik099\QATools\PageObject\Exception\UrlBuilderException::TYPE_MISSING_BASE_URL
+	 */
+	public function testConstructorMissingBasePath()
+	{
+		new UrlBuilder('/path');
 	}
 
 	/**
@@ -133,34 +385,34 @@ class UrlBuilderTest extends TestCase
 	{
 		return array(
 			array(
-				'/path',
+				'http://domain.tld/path',
 				array(),
-				'/path',
+				'http://domain.tld/path',
 			),
 			array(
-				'/path',
+				'http://domain.tld/path',
 				array('param' => 'value'),
-				'/path?param=value',
+				'http://domain.tld/path?param=value',
 			),
 			array(
-				'/path?param=value',
+				'http://domain.tld/path?param=value',
 				array(),
-				'/path?param=value',
+				'http://domain.tld/path?param=value',
 			),
 			array(
-				'/path?param1=value1',
+				'http://domain.tld/path?param1=value1',
 				array('param2' => 'value2'),
-				'/path?param1=value1&param2=value2',
+				'http://domain.tld/path?param1=value1&param2=value2',
 			),
 			array(
-				'/path?param=value1',
+				'http://domain.tld/path?param=value1',
 				array('param' => 'value2'),
-				'/path?param=value2',
+				'http://domain.tld/path?param=value2',
 			),
 			array(
-				'/path?param=value1#fragment',
+				'http://domain.tld/path?param=value1#fragment',
 				array('param' => 'value2'),
-				'/path?param=value2#fragment',
+				'http://domain.tld/path?param=value2#fragment',
 			),
 		);
 	}

--- a/tests/aik099/QATools/PageObject/Url/UrlParserTest.php
+++ b/tests/aik099/QATools/PageObject/Url/UrlParserTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * This file is part of the qa-tools library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/aik099/qa-tools
+ */
+
+namespace tests\aik099\QATools\PageObject\Url;
+
+
+use aik099\QATools\PageObject\Url\UrlParser;
+use Mockery as m;
+use tests\aik099\QATools\TestCase;
+
+class UrlParserTest extends TestCase
+{
+
+	/**
+	 * @dataProvider constructorAndGetterDataProvider
+	 */
+	public function testConstructorAndGetter(
+		$url,
+		$expected_scheme,
+		$expected_host,
+		$expected_path,
+		$expected_query,
+		$expected_fragment,
+		$expected_params
+	)
+	{
+		$url_parser = new UrlParser($url);
+
+		$this->assertEquals($expected_scheme, $url_parser->getComponent('scheme'));
+		$this->assertEquals($expected_host, $url_parser->getComponent('host'));
+		$this->assertEquals($expected_path, $url_parser->getComponent('path'));
+		$this->assertEquals($expected_query, $url_parser->getComponent('query'));
+		$this->assertEquals($expected_fragment, $url_parser->getComponent('fragment'));
+		$this->assertEquals($expected_params, $url_parser->getParams());
+	}
+
+	public function constructorAndGetterDataProvider()
+	{
+		return array(
+			array(
+				'http://domain.tld',
+				'http',
+				'domain.tld',
+				'',
+				'',
+				'',
+				array(),
+			),
+			array(
+				'http://domain.tld/path',
+				'http',
+				'domain.tld',
+				'/path',
+				'',
+				'',
+				array(),
+			),
+			array(
+				'http://domain.tld/path?param=value',
+				'http',
+				'domain.tld',
+				'/path',
+				'param=value',
+				'',
+				array('param' => 'value'),
+			),
+			array(
+				'http://domain.tld/path?param=value#anchor',
+				'http',
+				'domain.tld',
+				'/path',
+				'param=value',
+				'anchor',
+				array('param' => 'value'),
+			),
+		);
+	}
+
+	public function testGetComponentDefault()
+	{
+		$url_parser = new UrlParser('');
+
+		$this->assertEquals('default_scheme', $url_parser->getComponent('scheme', 'default_scheme'));
+		$this->assertEquals('default_host', $url_parser->getComponent('host', 'default_host'));
+		$this->assertEquals('default_path', $url_parser->getComponent('path', 'default_path'));
+		$this->assertEquals('default_query', $url_parser->getComponent('query', 'default_query'));
+		$this->assertEquals('default_fragment', $url_parser->getComponent('fragment', 'default_fragment'));
+	}
+
+	/**
+	 * @dataProvider mergeDataProvider
+	 */
+	public function testMerge($first_url, $second_url, $expected_component, $expected_value)
+	{
+		$url_parser = new UrlParser($first_url);
+		$url_parser->merge(new UrlParser($second_url));
+
+		$this->assertEquals($expected_value, $url_parser->getComponent($expected_component));
+	}
+
+	public function mergeDataProvider()
+	{
+		return array(
+			array('http://domain.tld#anchor', '/path?param=value', 'scheme', 'http'),
+			array('http://domain.tld#anchor', '/path?param=value', 'host', 'domain.tld'),
+			array('http://domain.tld#anchor', '/path?param=value', 'path', '/path'),
+			array('http://domain.tld#anchor', '/path?param=value', 'query', 'param=value'),
+			array('http://domain.tld#anchor', '/path?param=value', 'fragment', 'anchor'),
+		);
+	}
+
+}


### PR DESCRIPTION
I am currently not sure if we should pass the `base_url` in the constructor of UrlBuilderFactory or via `getUrlBuilder`.
I added it to `getUrlBuilder` this would allow us to exchange or set the config later via setter, cause the factory doesn't know about the `base_url`, just when we request a `UrlBuilder`.

Closes #60.
