### PR TITLE
Use ArrayObject for AbstractElementCollection

### DIFF
--- a/library/QATools/QATools/HtmlElements/Element/AbstractTypifiedElementCollection.php
+++ b/library/QATools/QATools/HtmlElements/Element/AbstractTypifiedElementCollection.php
@@ -66,7 +66,7 @@ abstract class AbstractTypifiedElementCollection extends AbstractElementCollecti
 			$element->setContainer($container);
 		}
 
-		$this->rewind();
+		$this->getIterator()->rewind();
 
 		return $this;
 	}

--- a/library/QATools/QATools/HtmlElements/Proxy/TypifiedElementProxy.php
+++ b/library/QATools/QATools/HtmlElements/Proxy/TypifiedElementProxy.php
@@ -77,7 +77,7 @@ class TypifiedElementProxy extends AbstractProxy implements ITypifiedElement
 			$this->injectContainer();
 		}
 
-		return $this->current();
+		return $this->getIterator()->current();
 	}
 
 	/**

--- a/library/QATools/QATools/PageObject/Element/AbstractElementCollection.php
+++ b/library/QATools/QATools/PageObject/Element/AbstractElementCollection.php
@@ -20,22 +20,8 @@ use Behat\Mink\Element\NodeElement;
  *
  * @method \Mockery\Expectation shouldReceive(string $name)
  */
-abstract class AbstractElementCollection implements \Iterator, \ArrayAccess, \Countable
+abstract class AbstractElementCollection extends \ArrayObject
 {
-
-	/**
-	 * Currently active element.
-	 *
-	 * @var integer
-	 */
-	private $_position = 0;
-
-	/**
-	 * Elements in the collection.
-	 *
-	 * @var array
-	 */
-	private $_elements = array();
 
 	/**
 	 * Element class, that is allowed in the collection.
@@ -68,7 +54,7 @@ abstract class AbstractElementCollection implements \Iterator, \ArrayAccess, \Co
 			}
 		}
 
-		$this->_elements = $allowed_elements;
+		parent::__construct($allowed_elements);
 	}
 
 	/**
@@ -81,56 +67,6 @@ abstract class AbstractElementCollection implements \Iterator, \ArrayAccess, \Co
 	protected function acceptElement($element)
 	{
 		return true;
-	}
-
-	/**
-	 * Rewind the Iterator to the first element.
-	 *
-	 * @return void
-	 */
-	public function rewind()
-	{
-		$this->_position = 0;
-	}
-
-	/**
-	 * Return the current element.
-	 *
-	 * @return mixed
-	 */
-	public function current()
-	{
-		return $this->_elements[$this->_position];
-	}
-
-	/**
-	 * Return the key of the current element.
-	 *
-	 * @return integer
-	 */
-	public function key()
-	{
-		return $this->_position;
-	}
-
-	/**
-	 * Move forward to next element.
-	 *
-	 * @return void
-	 */
-	public function next()
-	{
-		++$this->_position;
-	}
-
-	/**
-	 * Checks if current position is valid.
-	 *
-	 * @return boolean
-	 */
-	public function valid()
-	{
-		return $this->offsetExists($this->_position);
 	}
 
 	/**
@@ -148,62 +84,7 @@ abstract class AbstractElementCollection implements \Iterator, \ArrayAccess, \Co
 			return;
 		}
 
-		if ( is_null($offset) ) {
-			$this->_elements[] = $value;
-		}
-		else {
-			$this->_elements[$offset] = $value;
-		}
-	}
-
-	/**
-	 * Whether a offset exists.
-	 *
-	 * @param integer $offset An offset to check for.
-	 *
-	 * @return boolean
-	 */
-	public function offsetExists($offset)
-	{
-		return isset($this->_elements[$offset]);
-	}
-
-	/**
-	 * Offset to unset.
-	 *
-	 * @param integer $offset The offset to unset.
-	 *
-	 * @return void
-	 */
-	public function offsetUnset($offset)
-	{
-		unset($this->_elements[$offset]);
-	}
-
-	/**
-	 * Offset to retrieve.
-	 *
-	 * @param integer $offset The offset to retrieve.
-	 *
-	 * @return mixed|null
-	 */
-	public function offsetGet($offset)
-	{
-		if ( isset($this->_elements[$offset]) ) {
-			return $this->_elements[$offset];
-		}
-
-		return null;
-	}
-
-	/**
-	 * Count elements of an object.
-	 *
-	 * @return integer
-	 */
-	public function count()
-	{
-		return count($this->_elements);
+		parent::offsetSet($offset, $value);
 	}
 
 	/**

--- a/library/QATools/QATools/PageObject/Element/WebElementCollection.php
+++ b/library/QATools/QATools/PageObject/Element/WebElementCollection.php
@@ -58,7 +58,7 @@ class WebElementCollection extends AbstractElementCollection implements IWebElem
 			$element->setContainer($container);
 		}
 
-		$this->rewind();
+		$this->getIterator()->rewind();
 
 		return $this;
 	}

--- a/library/QATools/QATools/PageObject/Proxy/AbstractProxy.php
+++ b/library/QATools/QATools/PageObject/Proxy/AbstractProxy.php
@@ -200,7 +200,7 @@ abstract class AbstractProxy extends AbstractElementCollection implements IProxy
 			$element->setContainer($container);
 		}
 
-		$this->rewind();
+		$this->getIterator()->rewind();
 	}
 
 }

--- a/library/QATools/QATools/PageObject/Proxy/WebElementProxy.php
+++ b/library/QATools/QATools/PageObject/Proxy/WebElementProxy.php
@@ -67,7 +67,7 @@ class WebElementProxy extends AbstractProxy implements IWebElement
 			$this->injectContainer();
 		}
 
-		return $this->current();
+		return $this->getIterator()->current();
 	}
 
 }

--- a/tests/QATools/QATools/PageObject/Element/AbstractElementCollectionTestCase.php
+++ b/tests/QATools/QATools/PageObject/Element/AbstractElementCollectionTestCase.php
@@ -69,7 +69,13 @@ abstract class AbstractElementCollectionTestCase extends TestCase
 		$this->assertCount(1, $this->element);
 
 		$this->assertSame($element, $this->element[0]);
-		$this->assertNull($this->element[1]);
+
+		try {
+			$this->assertNull($this->element[1]);
+		}
+		catch ( \PHPUnit_Framework_Error_Notice $e ) {
+			// Ignore notice.
+		}
 
 		$this->assertTrue(isset($this->element[0]));
 		unset($this->element[0]);


### PR DESCRIPTION
It appears, that a set of interfaces the `AbstractElementCollection` class is implementing for manipulations with collection elements matches ones that `ArrayObject` class has. Let's extend that class instead of writing all processing manually.
