### PR TITLE
Store PageFactory in Page and not only BEMPage

### DIFF
--- a/library/QATools/QATools/BEM/BEMPage.php
+++ b/library/QATools/QATools/BEM/BEMPage.php
@@ -17,25 +17,6 @@ abstract class BEMPage extends Page
 {
 
 	/**
-	 * Page Factory, used to create a Page.
-	 *
-	 * @var BEMPageFactory
-	 */
-	protected $pageFactory = null;
-
-	/**
-	 * Initialize the page.
-	 *
-	 * @param BEMPageFactory $page_factory Page factory.
-	 */
-	public function __construct(BEMPageFactory $page_factory)
-	{
-		parent::__construct($page_factory);
-
-		$this->pageFactory = $page_factory;
-	}
-
-	/**
 	 * Initializes BEM page elements.
 	 *
 	 * @return void

--- a/library/QATools/QATools/PageObject/Page.php
+++ b/library/QATools/QATools/PageObject/Page.php
@@ -24,6 +24,13 @@ abstract class Page extends DocumentElement implements ISearchContext
 {
 
 	/**
+	 * Page factory, used to create a Page.
+	 *
+	 * @var IPageFactory
+	 */
+	protected $pageFactory = null;
+
+	/**
 	 * The builder which generates the url.
 	 *
 	 * @var IBuilder
@@ -39,7 +46,9 @@ abstract class Page extends DocumentElement implements ISearchContext
 	{
 		parent::__construct($page_factory->getSession());
 
-		$page_factory->initPage($this)->initElements($this, $page_factory->createDecorator($this));
+		$this->pageFactory = $page_factory;
+
+		$this->pageFactory->initPage($this)->initElements($this, $this->pageFactory->createDecorator($this));
 	}
 
 	/**


### PR DESCRIPTION
I moved down the code for storage as suggested and removed the empty constructor override, which gave the typehint for a `BEMPageFactory`, we could keep it to keep warnings by the IDE.

I did not add any tests, because `getPageFactory` is **protected** and `Page` is currently not using it in any way. But do we really need this getter? Because it is protected and not private and can be accessed directly, maybe we should set the page factory to **private**, it shouldn't be modified by any ancestor in any way.

Closes #84
