### PR TITLE
Adding assert for type and tag

### DIFF
--- a/library/QATools/QATools/HtmlElements/Element/AbstractTypifiedElement.php
+++ b/library/QATools/QATools/HtmlElements/Element/AbstractTypifiedElement.php
@@ -11,12 +11,13 @@
 namespace QATools\QATools\HtmlElements\Element;
 
 
-use QATools\QATools\PageObject\Element\INodeElementAware;
-use QATools\QATools\PageObject\IPageFactory;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Selector\SelectorsHandler;
 use Behat\Mink\Session;
+use QATools\QATools\HtmlElements\Exception\TypifiedElementException;
+use QATools\QATools\PageObject\Element\INodeElementAware;
 use QATools\QATools\PageObject\Element\WebElement;
+use QATools\QATools\PageObject\IPageFactory;
 
 /**
  * The base class to be used for making classes representing typified elements (i.e web page controls such as
@@ -26,6 +27,9 @@ use QATools\QATools\PageObject\Element\WebElement;
  */
 abstract class AbstractTypifiedElement implements ITypifiedElement, INodeElementAware
 {
+	const CRITERION_TAG = 'tag';
+
+	const CRITERION_ATTR = 'attrs';
 
 	/**
 	 * Name of the element.
@@ -42,6 +46,13 @@ abstract class AbstractTypifiedElement implements ITypifiedElement, INodeElement
 	private $_wrappedElement;
 
 	/**
+	 * List of acceptance criteria.
+	 *
+	 * @var array
+	 */
+	protected $acceptanceCriteria = array();
+
+	/**
 	 * Specifies wrapped WebElement.
 	 *
 	 * @param WebElement $wrapped_element Element to be wrapped.
@@ -49,6 +60,8 @@ abstract class AbstractTypifiedElement implements ITypifiedElement, INodeElement
 	public function __construct(WebElement $wrapped_element)
 	{
 		$this->_wrappedElement = $wrapped_element;
+
+		$this->assertWrappedElement();
 	}
 
 	/**
@@ -64,6 +77,89 @@ abstract class AbstractTypifiedElement implements ITypifiedElement, INodeElement
 		$wrapped_element = WebElement::fromNodeElement($node_element);
 
 		return new static($wrapped_element);
+	}
+
+	/**
+	 * Checks that wrapped element meets the acceptance criteria.
+	 *
+	 * @return void
+	 * @throws TypifiedElementException When no criteria matches.
+	 */
+	protected function assertWrappedElement()
+	{
+		if ( !$this->acceptanceCriteria ) {
+			return;
+		}
+
+		foreach ( $this->acceptanceCriteria as $criterion ) {
+			if ( !$this->isTagNameMatching($criterion) ) {
+				continue;
+			}
+
+			if ( $this->isAttributeMatching($criterion) ) {
+				return;
+			}
+		}
+
+		$message = 'Wrapped element "%s" does not match "%s" criteria';
+
+		throw new TypifiedElementException(
+			sprintf($message, $this->getWrappedElement(), get_class($this)),
+			TypifiedElementException::TYPE_INCORRECT_WRAPPED_ELEMENT
+		);
+	}
+
+	/**
+	 * Checks if the tag name(s) of the criterion are matching.
+	 *
+	 * @param array $criterion The criterion.
+	 *
+	 * @return boolean
+	 */
+	protected function isTagNameMatching(array $criterion)
+	{
+		if ( !isset($criterion[self::CRITERION_TAG]) ) {
+			return true;
+		}
+
+		return $this->isValueMatchingCriterionDefinition($this->getTagName(), $criterion[self::CRITERION_TAG]);
+	}
+
+	/**
+	 * Checks if the attributes of the criterion are matching.
+	 *
+	 * @param array $criterion The criterion.
+	 *
+	 * @return boolean
+	 */
+	protected function isAttributeMatching(array $criterion)
+	{
+		if ( !isset($criterion[self::CRITERION_ATTR]) ) {
+			return true;
+		}
+
+		foreach ( $criterion[self::CRITERION_ATTR] as $attribute => $definition ) {
+			if ( $this->isValueMatchingCriterionDefinition($this->getAttribute($attribute), $definition) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks if passed value matching the defined criterion.
+	 *
+	 * @param string $value     Value to match.
+	 * @param string $criterion The criterion.
+	 *
+	 * @return boolean
+	 */
+	protected function isValueMatchingCriterionDefinition($value, $criterion)
+	{
+		$criterion = '/^(' . str_replace('*', '.*', $criterion) . ')$/';
+
+		return preg_match($criterion, $value);
 	}
 
 	/**

--- a/library/QATools/QATools/HtmlElements/Element/AbstractTypifiedElement.php
+++ b/library/QATools/QATools/HtmlElements/Element/AbstractTypifiedElement.php
@@ -29,7 +29,7 @@ abstract class AbstractTypifiedElement implements ITypifiedElement, INodeElement
 {
 	const CRITERION_TAG = 'tag';
 
-	const CRITERION_ATTR = 'attrs';
+	const CRITERION_ATTRS = 'attrs';
 
 	/**
 	 * Name of the element.
@@ -134,11 +134,11 @@ abstract class AbstractTypifiedElement implements ITypifiedElement, INodeElement
 	 */
 	protected function isAttributeMatching(array $criterion)
 	{
-		if ( !isset($criterion[self::CRITERION_ATTR]) ) {
+		if ( !isset($criterion[self::CRITERION_ATTRS]) ) {
 			return true;
 		}
 
-		foreach ( $criterion[self::CRITERION_ATTR] as $attribute => $definition ) {
+		foreach ( $criterion[self::CRITERION_ATTRS] as $attribute => $definition ) {
 			if ( $this->isValueMatchingCriterionDefinition($this->getAttribute($attribute), $definition) ) {
 				return true;
 			}
@@ -157,9 +157,7 @@ abstract class AbstractTypifiedElement implements ITypifiedElement, INodeElement
 	 */
 	protected function isValueMatchingCriterionDefinition($value, $criterion)
 	{
-		$criterion = '/^(' . str_replace('*', '.*', $criterion) . ')$/';
-
-		return preg_match($criterion, $value);
+		return preg_match('/^(' . str_replace('*', '.*', $criterion) . ')$/', $value);
 	}
 
 	/**

--- a/library/QATools/QATools/HtmlElements/Element/Button.php
+++ b/library/QATools/QATools/HtmlElements/Element/Button.php
@@ -18,6 +18,17 @@ class Button extends AbstractTypifiedElement
 {
 
 	/**
+	 * List of acceptance criteria.
+	 *
+	 * @var array
+	 */
+	protected $acceptanceCriteria = array(
+		array('tag' => 'input', 'attrs' => array('type' => 'submit|button')),
+		array('tag' => 'button'),
+		array('attrs' => array('role' => 'button')),
+	);
+
+	/**
 	 * Clicks the button.
 	 *
 	 * @return self

--- a/library/QATools/QATools/HtmlElements/Element/Checkbox.php
+++ b/library/QATools/QATools/HtmlElements/Element/Checkbox.php
@@ -18,6 +18,15 @@ class Checkbox extends LabeledElement implements ISimpleSetter
 {
 
 	/**
+	 * List of acceptance criteria.
+	 *
+	 * @var array
+	 */
+	protected $acceptanceCriteria = array(
+		array('tag' => 'input', 'attrs' => array('type' => 'checkbox')),
+	);
+
+	/**
 	 * Checks checkbox if it is not already checked.
 	 *
 	 * @return self

--- a/library/QATools/QATools/HtmlElements/Element/FileInput.php
+++ b/library/QATools/QATools/HtmlElements/Element/FileInput.php
@@ -20,6 +20,15 @@ class FileInput extends AbstractTypifiedElement implements ISimpleSetter
 {
 
 	/**
+	 * List of acceptance criteria.
+	 *
+	 * @var array
+	 */
+	protected $acceptanceCriteria = array(
+		array('tag' => 'input', 'attrs' => array('type' => 'file')),
+	);
+
+	/**
 	 * Indicates whether this select element support selecting multiple options at the same time.
 	 *
 	 * @return boolean

--- a/library/QATools/QATools/HtmlElements/Element/RadioButton.php
+++ b/library/QATools/QATools/HtmlElements/Element/RadioButton.php
@@ -18,6 +18,15 @@ class RadioButton extends LabeledElement
 {
 
 	/**
+	 * List of acceptance criteria.
+	 *
+	 * @var array
+	 */
+	protected $acceptanceCriteria = array(
+		array('tag' => 'input', 'attrs' => array('type' => 'radio')),
+	);
+
+	/**
 	 * Selects radio button uf it's not already selected.
 	 *
 	 * @return self

--- a/library/QATools/QATools/HtmlElements/Element/Select.php
+++ b/library/QATools/QATools/HtmlElements/Element/Select.php
@@ -22,6 +22,15 @@ class Select extends AbstractTypifiedElement implements ISimpleSetter
 {
 
 	/**
+	 * List of acceptance criteria.
+	 *
+	 * @var array
+	 */
+	protected $acceptanceCriteria = array(
+		array('tag' => 'select'),
+	);
+
+	/**
 	 * Indicates whether this select element support selecting multiple options at the same time.
 	 *
 	 * @return boolean

--- a/library/QATools/QATools/HtmlElements/Element/SelectOption.php
+++ b/library/QATools/QATools/HtmlElements/Element/SelectOption.php
@@ -27,6 +27,15 @@ class SelectOption extends AbstractTypifiedElement
 	protected $select;
 
 	/**
+	 * List of acceptance criteria.
+	 *
+	 * @var array
+	 */
+	protected $acceptanceCriteria = array(
+		array('tag' => 'option'),
+	);
+
+	/**
 	 * Sets reference to parent SELECT element.
 	 *
 	 * @param Select $select Associated SELECT element.

--- a/library/QATools/QATools/HtmlElements/Element/TextInput.php
+++ b/library/QATools/QATools/HtmlElements/Element/TextInput.php
@@ -18,6 +18,15 @@ class TextInput extends AbstractTypifiedElement implements ISimpleSetter
 {
 
 	/**
+	 * List of acceptance criteria.
+	 *
+	 * @var array
+	 */
+	protected $acceptanceCriteria = array(
+		array('tag' => 'input|textarea'),
+	);
+
+	/**
 	 * Clears all the text entered into this text input.
 	 *
 	 * @return self

--- a/library/QATools/QATools/HtmlElements/Exception/TypifiedElementException.php
+++ b/library/QATools/QATools/HtmlElements/Exception/TypifiedElementException.php
@@ -18,5 +18,5 @@ use QATools\QATools\PageObject\Exception\ElementException;
  */
 class TypifiedElementException extends ElementException
 {
-
+	const TYPE_INCORRECT_WRAPPED_ELEMENT = 201;
 }

--- a/tests/QATools/QATools/HtmlElements/Element/ButtonTest.php
+++ b/tests/QATools/QATools/HtmlElements/Element/ButtonTest.php
@@ -40,6 +40,7 @@ class ButtonTest extends AbstractTypifiedElementTest
 	/**
 	 * @expectedException \QATools\QATools\HtmlElements\Exception\TypifiedElementException
 	 * @expectedExceptionCode \QATools\QATools\HtmlElements\Exception\TypifiedElementException::TYPE_INCORRECT_WRAPPED_ELEMENT
+	 * @expectedExceptionMessageRegExp /^Wrapped element "Mockery.*?" does not match "QATools\\QATools\\HtmlElements\\Element\\Button" criteria$/
 	 */
 	public function testAssertWrappedElementTagNotMatching()
 	{
@@ -57,6 +58,7 @@ class ButtonTest extends AbstractTypifiedElementTest
 	/**
 	 * @expectedException \QATools\QATools\HtmlElements\Exception\TypifiedElementException
 	 * @expectedExceptionCode \QATools\QATools\HtmlElements\Exception\TypifiedElementException::TYPE_INCORRECT_WRAPPED_ELEMENT
+	 * @expectedExceptionMessageRegExp /^Wrapped element "Mockery.*?" does not match "QATools\\QATools\\HtmlElements\\Element\\Button" criteria$/
 	 */
 	public function testAssertWrappedElementAttributeNotMatching()
 	{

--- a/tests/QATools/QATools/HtmlElements/Element/ButtonTest.php
+++ b/tests/QATools/QATools/HtmlElements/Element/ButtonTest.php
@@ -22,6 +22,11 @@ class ButtonTest extends AbstractTypifiedElementTest
 			$this->elementClass = '\\QATools\\QATools\\HtmlElements\\Element\\Button';
 		}
 
+		$this->expectedTagName = 'button';
+
+		$this->ignoreExpectTypifiedNodeCheck[] = 'testAssertWrappedElementTagNotMatching';
+		$this->ignoreExpectTypifiedNodeCheck[] = 'testAssertWrappedElementAttributeNotMatching';
+
 		parent::setUp();
 	}
 
@@ -30,6 +35,65 @@ class ButtonTest extends AbstractTypifiedElementTest
 		$this->webElement->shouldReceive('click')->once();
 
 		$this->assertSame($this->typifiedElement, $this->getElement()->click());
+	}
+
+	/**
+	 * @expectedException \QATools\QATools\HtmlElements\Exception\TypifiedElementException
+	 * @expectedExceptionCode \QATools\QATools\HtmlElements\Exception\TypifiedElementException::TYPE_INCORRECT_WRAPPED_ELEMENT
+	 */
+	public function testAssertWrappedElementTagNotMatching()
+	{
+		$this->expectDriverGetTagName($this->expectedTagName . '_postfix');
+		$this->expectWebElementGetTagName($this->expectedTagName . '_postfix');
+
+		$this->expectDriverGetAttribute(array('role' => 'link'));
+		$this->expectWebElementGetAttribute(array('role' => 'link'));
+
+		$this->typifiedElement = $this->createElement();
+
+		$this->assertSame($this->webElement, $this->typifiedElement->getWrappedElement());
+	}
+
+	/**
+	 * @expectedException \QATools\QATools\HtmlElements\Exception\TypifiedElementException
+	 * @expectedExceptionCode \QATools\QATools\HtmlElements\Exception\TypifiedElementException::TYPE_INCORRECT_WRAPPED_ELEMENT
+	 */
+	public function testAssertWrappedElementAttributeNotMatching()
+	{
+		$this->expectDriverGetTagName('input');
+		$this->expectWebElementGetTagName('input');
+
+		$this->expectDriverGetAttribute(array('type' => 'checkbox', 'role' => 'link'));
+		$this->expectWebElementGetAttribute(array('type' => 'checkbox', 'role' => 'link'));
+
+		$this->typifiedElement = $this->createElement();
+
+		$this->assertSame($this->webElement, $this->typifiedElement->getWrappedElement());
+	}
+
+	/**
+	 * @dataProvider assertWrappedElementAttributeMatchingDataProvider
+	 */
+	public function testAssertWrappedElementAttributeMatching($attributes)
+	{
+		$this->expectDriverGetTagName('input');
+		$this->expectWebElementGetTagName('input');
+
+		$this->expectDriverGetAttribute($attributes);
+		$this->expectWebElementGetAttribute($attributes);
+
+		$this->typifiedElement = $this->createElement();
+
+		$this->assertSame($this->webElement, $this->typifiedElement->getWrappedElement());
+	}
+
+	public function assertWrappedElementAttributeMatchingDataProvider()
+	{
+		return array(
+			array(array('type' => 'button', 'role' => 'link')),
+			array(array('type' => 'submit', 'role' => 'link')),
+			array(array('type' => 'checkbox', 'role' => 'button')),
+		);
 	}
 
 	/**

--- a/tests/QATools/QATools/HtmlElements/Element/CheckboxTest.php
+++ b/tests/QATools/QATools/HtmlElements/Element/CheckboxTest.php
@@ -23,6 +23,8 @@ class CheckboxTest extends LabeledElementTest
 			$this->elementClass = '\\QATools\\QATools\\HtmlElements\\Element\\Checkbox';
 		}
 
+		$this->expectedAttributes = array('type' => 'checkbox');
+
 		parent::setUp();
 	}
 

--- a/tests/QATools/QATools/HtmlElements/Element/ElementWithAttributeWildcardAcceptanceCriteriaTest.php
+++ b/tests/QATools/QATools/HtmlElements/Element/ElementWithAttributeWildcardAcceptanceCriteriaTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This file is part of the QA-Tools library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/qa-tools/qa-tools
+ */
+
+namespace tests\QATools\QATools\HtmlElements\Element;
+
+
+class ElementWithAttributeWildcardAcceptanceCriteriaTest extends AbstractTypifiedElementTest
+{
+
+	protected function setUp()
+	{
+		if ( is_null($this->elementClass) ) {
+			$this->elementClass = '\\tests\\QATools\\QATools\\HtmlElements\\Fixture\\Element\\ElementWithAttributeWildcardAcceptanceCriteria';
+		}
+
+		$this->expectedTagName = 'button';
+		$this->expectedAttributes = array('class' => 'test');
+
+		parent::setUp();
+	}
+
+}

--- a/tests/QATools/QATools/HtmlElements/Element/ElementWithTagWildcardAcceptanceCriteriaTest.php
+++ b/tests/QATools/QATools/HtmlElements/Element/ElementWithTagWildcardAcceptanceCriteriaTest.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This file is part of the QA-Tools library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/qa-tools/qa-tools
+ */
+
+namespace tests\QATools\QATools\HtmlElements\Element;
+
+
+class ElementWithTagWildcardAcceptanceCriteriaTest extends AbstractTypifiedElementTest
+{
+
+	protected function setUp()
+	{
+		if ( is_null($this->elementClass) ) {
+			$this->elementClass = '\\tests\\QATools\\QATools\\HtmlElements\\Fixture\\Element\\ElementWithTagWildcardAcceptanceCriteria';
+		}
+
+		$this->expectedTagName = 'button';
+
+		parent::setUp();
+	}
+
+}

--- a/tests/QATools/QATools/HtmlElements/Element/ElementWithoutTagAcceptanceCriteriaTest.php
+++ b/tests/QATools/QATools/HtmlElements/Element/ElementWithoutTagAcceptanceCriteriaTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This file is part of the QA-Tools library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/qa-tools/qa-tools
+ */
+
+namespace tests\QATools\QATools\HtmlElements\Element;
+
+
+class ElementWithoutTagAcceptanceCriteriaTest extends AbstractTypifiedElementTest
+{
+
+	protected function setUp()
+	{
+		if ( is_null($this->elementClass) ) {
+			$this->elementClass = '\\tests\\QATools\\QATools\\HtmlElements\\Fixture\\Element\\ElementWithoutTagAcceptanceCriteria';
+		}
+
+		$this->expectedTagName = 'button';
+		$this->expectedAttributes = array('class' => 'test');
+
+		parent::setUp();
+	}
+
+}

--- a/tests/QATools/QATools/HtmlElements/Element/FileInputTest.php
+++ b/tests/QATools/QATools/HtmlElements/Element/FileInputTest.php
@@ -23,6 +23,8 @@ class FileInputTest extends AbstractTypifiedElementTest
 			$this->elementClass = '\\QATools\\QATools\\HtmlElements\\Element\\FileInput';
 		}
 
+		$this->expectedAttributes = array('type' => 'file');
+
 		parent::setUp();
 	}
 

--- a/tests/QATools/QATools/HtmlElements/Element/FormTest.php
+++ b/tests/QATools/QATools/HtmlElements/Element/FormTest.php
@@ -26,6 +26,8 @@ class FormTest extends AbstractElementContainerTest
 			$this->elementClass = '\\QATools\\QATools\\HtmlElements\\Element\\Form';
 		}
 
+		$this->ignoreExpectTypifiedNodeCheck[] = 'testTypify';
+
 		parent::setUp();
 	}
 
@@ -109,15 +111,20 @@ class FormTest extends AbstractElementContainerTest
 	 */
 	public function testTypify($tag_name, $input_type, $element_class)
 	{
-		// 2 times for radio, because radio is wrapped within a collection and is asserted.
-		$call_count = $input_type == 'radio' ? 2 : 1;
+		// 3 times for radio, because radio is wrapped within a collection and is asserted.
+		$call_count = $input_type == 'radio' ? 3 : 2;
 
 		$node_element = new NodeElement('XPATH', $this->session);
 		$this->driver->shouldReceive('getTagName')->with('XPATH')->times($call_count)->andReturn($tag_name);
 
 		if ( $tag_name == 'input' ) {
-			$this->driver->shouldReceive('getAttribute')->with('XPATH', 'type')->times($call_count)->andReturn($input_type);
+			$this->driver
+				->shouldReceive('getAttribute')
+				->with('XPATH', 'type')->atLeast($call_count - 1)
+				->andReturn($input_type);
 		}
+
+		$this->typifiedElement = $this->createElement();
 
 		$form_element = $this->getElement()->typify(array($node_element));
 		$this->assertInstanceOf($element_class, $form_element);

--- a/tests/QATools/QATools/HtmlElements/Element/RadioTest.php
+++ b/tests/QATools/QATools/HtmlElements/Element/RadioTest.php
@@ -23,6 +23,8 @@ class RadioTest extends LabeledElementTest
 			$this->elementClass = '\\QATools\\QATools\\HtmlElements\\Element\\RadioButton';
 		}
 
+		$this->expectedAttributes = array('type' => 'radio');
+
 		parent::setUp();
 	}
 

--- a/tests/QATools/QATools/HtmlElements/Element/SelectOptionTest.php
+++ b/tests/QATools/QATools/HtmlElements/Element/SelectOptionTest.php
@@ -34,6 +34,7 @@ class SelectOptionTest extends AbstractTypifiedElementTest
 		}
 
 		$this->select = m::mock('\\QATools\\QATools\\HtmlElements\\Element\\Select');
+		$this->expectedTagName = 'option';
 
 		parent::setUp();
 	}

--- a/tests/QATools/QATools/HtmlElements/Element/SelectTest.php
+++ b/tests/QATools/QATools/HtmlElements/Element/SelectTest.php
@@ -147,7 +147,9 @@ class SelectTest extends AbstractTypifiedElementTest
 
 		/* @var $element Select */
 		$element = $this->mockElement(array('getOptions'));
-		$element->shouldReceive('getOptions')->andReturn(array($not_selected_option, $selected_option1, $selected_option2));
+		$element
+			->shouldReceive('getOptions')
+			->andReturn(array($not_selected_option, $selected_option1, $selected_option2));
 
 		$option = $element->getFirstSelectedOption();
 		$this->assertValidOptions(array($option));

--- a/tests/QATools/QATools/HtmlElements/Element/SelectTest.php
+++ b/tests/QATools/QATools/HtmlElements/Element/SelectTest.php
@@ -26,7 +26,23 @@ class SelectTest extends AbstractTypifiedElementTest
 			$this->elementClass = '\\QATools\\QATools\\HtmlElements\\Element\\Select';
 		}
 
+		$this->ignoreExpectTypifiedNodeCheck[] = 'testGetOptions';
+		$this->ignoreExpectTypifiedNodeCheck[] = 'testGetOptionsByValue';
+		$this->ignoreExpectTypifiedNodeCheck[] = 'testGetOptionsByText';
+
+		$this->expectedTagName = 'select';
+
 		parent::setUp();
+	}
+
+	/**
+	 * Occurs before element creation in setUp.
+	 *
+	 * @return void
+	 */
+	protected function setUpBeforeCreateElement()
+	{
+		$this->expectWebElementGetTagName('select');
 	}
 
 	/**
@@ -49,15 +65,21 @@ class SelectTest extends AbstractTypifiedElementTest
 
 	public function testGetOptions()
 	{
+		$this->expectDriverGetTagName('option');
+
 		$this->webElement->shouldReceive('findAll')->with('se', array('tagName' => 'option'))->once()->andReturn(
 			array($this->createNodeElement())
 		);
+
+		$this->typifiedElement = $this->createElement();
 
 		$this->assertValidOptions($this->getElement()->getOptions());
 	}
 
 	public function testGetOptionsByValue()
 	{
+		$this->expectDriverGetTagName('option');
+
 		$this->selectorsHandler->shouldReceive('xpathLiteral')->with('SV')->andReturn('SV');
 
 		$this->webElement
@@ -68,6 +90,8 @@ class SelectTest extends AbstractTypifiedElementTest
 				array($this->createNodeElement())
 			);
 
+		$this->typifiedElement = $this->createElement();
+
 		$this->assertValidOptions($this->getElement()->getOptionsByValue('SV'));
 	}
 
@@ -76,6 +100,8 @@ class SelectTest extends AbstractTypifiedElementTest
 	 */
 	public function testGetOptionsByText($exact_match)
 	{
+		$this->expectDriverGetTagName('option');
+
 		$this->selectorsHandler->shouldReceive('xpathLiteral')->with('SV')->andReturn('SV');
 
 		if ( $exact_match ) {
@@ -89,11 +115,15 @@ class SelectTest extends AbstractTypifiedElementTest
 			array($this->createNodeElement())
 		);
 
+		$this->typifiedElement = $this->createElement();
+
 		$this->assertValidOptions($this->getElement()->getOptionsByText('SV', $exact_match));
 	}
 
 	public function testGetSelectedOptions()
 	{
+		$this->expectDriverGetTagName('option');
+
 		$selected_option = $this->createOption(true);
 		$not_selected_option = $this->createOption(false);
 
@@ -109,6 +139,8 @@ class SelectTest extends AbstractTypifiedElementTest
 
 	public function testGetFirstSelectedOptionSuccess()
 	{
+		$this->expectDriverGetTagName('option');
+
 		$selected_option1 = $this->createOption(true);
 		$selected_option2 = $this->createOption(true);
 		$not_selected_option = $this->createOption(false);
@@ -130,6 +162,8 @@ class SelectTest extends AbstractTypifiedElementTest
 	 */
 	public function testGetFirstSelectedOptionError()
 	{
+		$this->expectDriverGetTagName('option');
+
 		/* @var $element Select */
 		$element = $this->mockElement(array('getOptions'));
 		$element->shouldReceive('getOptions')->andReturn(array());

--- a/tests/QATools/QATools/HtmlElements/Fixture/Element/ElementWithAttributeWildcardAcceptanceCriteria.php
+++ b/tests/QATools/QATools/HtmlElements/Fixture/Element/ElementWithAttributeWildcardAcceptanceCriteria.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This file is part of the QA-Tools library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/qa-tools/qa-tools
+ */
+
+namespace tests\QATools\QATools\HtmlElements\Fixture\Element;
+
+
+use QATools\QATools\HtmlElements\Element\AbstractTypifiedElement;
+
+class ElementWithAttributeWildcardAcceptanceCriteria extends AbstractTypifiedElement
+{
+
+	/**
+	 * List of acceptance criteria.
+	 *
+	 * @var array
+	 */
+	protected $acceptanceCriteria = array(
+		array('attrs' => array('class' => '*')),
+	);
+
+}

--- a/tests/QATools/QATools/HtmlElements/Fixture/Element/ElementWithTagWildcardAcceptanceCriteria.php
+++ b/tests/QATools/QATools/HtmlElements/Fixture/Element/ElementWithTagWildcardAcceptanceCriteria.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This file is part of the QA-Tools library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/qa-tools/qa-tools
+ */
+
+namespace tests\QATools\QATools\HtmlElements\Fixture\Element;
+
+
+use QATools\QATools\HtmlElements\Element\AbstractTypifiedElement;
+
+class ElementWithTagWildcardAcceptanceCriteria extends AbstractTypifiedElement
+{
+
+	/**
+	 * List of acceptance criteria.
+	 *
+	 * @var array
+	 */
+	protected $acceptanceCriteria = array(
+		array('tag' => '*'),
+	);
+
+}

--- a/tests/QATools/QATools/HtmlElements/Fixture/Element/ElementWithoutTagAcceptanceCriteria.php
+++ b/tests/QATools/QATools/HtmlElements/Fixture/Element/ElementWithoutTagAcceptanceCriteria.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This file is part of the QA-Tools library.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @copyright Alexander Obuhovich <aik.bold@gmail.com>
+ * @link      https://github.com/qa-tools/qa-tools
+ */
+
+namespace tests\QATools\QATools\HtmlElements\Fixture\Element;
+
+
+use QATools\QATools\HtmlElements\Element\AbstractTypifiedElement;
+
+class ElementWithoutTagAcceptanceCriteria extends AbstractTypifiedElement
+{
+
+	/**
+	 * List of acceptance criteria.
+	 *
+	 * @var array
+	 */
+	protected $acceptanceCriteria = array(
+		array('attrs' => array('class' => 'test')),
+	);
+
+}

--- a/tests/QATools/QATools/HtmlElements/Proxy/TypifiedElementCollectionProxyTest.php
+++ b/tests/QATools/QATools/HtmlElements/Proxy/TypifiedElementCollectionProxyTest.php
@@ -29,6 +29,13 @@ class TypifiedElementCollectionProxyTest extends TypifiedElementProxyTest
 		parent::setUp();
 	}
 
+	protected function beforeSetUpFinish()
+	{
+		parent::beforeSetUpFinish();
+
+		$this->expectDriverGetTagName('textarea');
+	}
+
 	public function testDefaultClassName()
 	{
 		$this->assertInstanceOf(self::ELEMENT_CLASS, $this->element->getObject());

--- a/tests/QATools/QATools/HtmlElements/Proxy/TypifiedElementProxyTest.php
+++ b/tests/QATools/QATools/HtmlElements/Proxy/TypifiedElementProxyTest.php
@@ -41,6 +41,9 @@ class TypifiedElementProxyTest extends AbstractProxyTestCase
 	{
 		$expected = '\\tests\\QATools\\QATools\\HtmlElements\\Fixture\\Element\\ButtonChild';
 
+		$this->expectDriverGetTagName('button');
+		$this->expectDriverGetAttribute(array('type' => 'submit'));
+
 		$this->element->setClassName($expected);
 		$this->assertInstanceOf($expected, $this->element->getObject());
 	}

--- a/tests/QATools/QATools/TestCase.php
+++ b/tests/QATools/QATools/TestCase.php
@@ -66,6 +66,32 @@ class TestCase extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
+	 * Mocks getTagName in the driver.
+	 *
+	 * @param string $tag_name Mocked return value.
+	 *
+	 * @return void
+	 */
+	protected function expectDriverGetTagName($tag_name)
+	{
+		$this->driver->shouldReceive('getTagName')->with('XPATH')->andReturn($tag_name);
+	}
+
+	/**
+	 * Mocks getAttribute in the driver.
+	 *
+	 * @param array $attributes Mocked attributes.
+	 *
+	 * @return void
+	 */
+	protected function expectDriverGetAttribute(array $attributes)
+	{
+		foreach ( $attributes as $attribute => $value ) {
+			$this->driver->shouldReceive('getAttribute')->with('XPATH', $attribute)->andReturn($value);
+		}
+	}
+
+	/**
 	 * Creates NodeElement mock.
 	 *
 	 * @param string|null $xpath XPath of the element.


### PR DESCRIPTION
Implements `assertWrappedElement` to check for correct wrapped element in typified elements.

Closes #53 