### PR TITLE
Use escape literal

### DIFF
--- a/library/QATools/QATools/HtmlElements/Element/AbstractTypifiedElement.php
+++ b/library/QATools/QATools/HtmlElements/Element/AbstractTypifiedElement.php
@@ -12,7 +12,7 @@ namespace QATools\QATools\HtmlElements\Element;
 
 
 use Behat\Mink\Element\NodeElement;
-use Behat\Mink\Selector\SelectorsHandler;
+use Behat\Mink\Selector\Xpath\Escaper;
 use Behat\Mink\Session;
 use QATools\QATools\HtmlElements\Exception\TypifiedElementException;
 use QATools\QATools\PageObject\Element\INodeElementAware;
@@ -161,6 +161,16 @@ abstract class AbstractTypifiedElement implements ITypifiedElement, INodeElement
 	}
 
 	/**
+	 * Get the XPath escaper.
+	 *
+	 * @return Escaper
+	 */
+	public function getXpathEscaper()
+	{
+		return $this->getWrappedElement()->getXpathEscaper();
+	}
+
+	/**
 	 * Returns wrapped element.
 	 *
 	 * @return WebElement
@@ -268,16 +278,6 @@ abstract class AbstractTypifiedElement implements ITypifiedElement, INodeElement
 	public function getTagName()
 	{
 		return $this->getWrappedElement()->getTagName();
-	}
-
-	/**
-	 * Returns selectors handler.
-	 *
-	 * @return SelectorsHandler
-	 */
-	protected function getSelectorsHandler()
-	{
-		return $this->getSession()->getSelectorsHandler();
 	}
 
 	/**

--- a/library/QATools/QATools/HtmlElements/Element/Form.php
+++ b/library/QATools/QATools/HtmlElements/Element/Form.php
@@ -59,7 +59,10 @@ class Form extends AbstractElementContainer
 	 */
 	public function getNodeElements($field_name)
 	{
-		$node_elements = $this->findAll('named', array('field', $this->_autoEscapeForXpath($field_name)));
+		$node_elements = $this->findAll(
+			'named',
+			array('field', $this->getXpathEscaper()->escapeLiteral($field_name))
+		);
 
 		if ( empty($node_elements) ) {
 			throw new FormException(
@@ -69,25 +72,6 @@ class Form extends AbstractElementContainer
 		}
 
 		return $node_elements;
-	}
-
-	/**
-	 * Determines if Mink does automatic selector escaping.
-	 *
-	 * @param string $string Text to escape.
-	 *
-	 * @return string
-	 */
-	private function _autoEscapeForXpath($string)
-	{
-		$selectors_handler = $this->getSelectorsHandler();
-
-		// Needed for Mink 1.x and below.
-		if ( method_exists($selectors_handler, 'xpathLiteral') ) {
-			$string = $selectors_handler->xpathLiteral($string);
-		}
-
-		return $string;
 	}
 
 	/**

--- a/library/QATools/QATools/HtmlElements/Element/LabeledElement.php
+++ b/library/QATools/QATools/HtmlElements/Element/LabeledElement.php
@@ -31,7 +31,7 @@ class LabeledElement extends AbstractTypifiedElement
 
 		if ( !is_null($id) ) {
 			// Label with matching "for" attribute.
-			$escaped_id = $this->getSelectorsHandler()->xpathLiteral($id);
+			$escaped_id = $this->getXpathEscaper()->escapeLiteral($id);
 			$xpath_expressions = array(
 				'preceding::label[@for = ' . $escaped_id . ']',
 				'following::label[@for = ' . $escaped_id . ']',

--- a/library/QATools/QATools/HtmlElements/Element/Select.php
+++ b/library/QATools/QATools/HtmlElements/Element/Select.php
@@ -59,8 +59,7 @@ class Select extends AbstractTypifiedElement implements ISimpleSetter
 	 */
 	public function getOptionsByValue($value)
 	{
-		$selectors_handler = $this->getSelectorsHandler();
-		$xpath = 'descendant-or-self::option[@value = ' . $selectors_handler->xpathLiteral($value) . ']';
+		$xpath = 'descendant-or-self::option[@value = ' . $this->getXpathEscaper()->escapeLiteral($value) . ']';
 
 		return $this->wrapOptions($this->getWrappedElement()->findAll('xpath', $xpath));
 	}
@@ -75,13 +74,11 @@ class Select extends AbstractTypifiedElement implements ISimpleSetter
 	 */
 	public function getOptionsByText($text, $exact_match = true)
 	{
-		$selectors_handler = $this->getSelectorsHandler();
-
 		if ( $exact_match ) {
-			$xpath = 'descendant-or-self::option[normalize-space(.) = ' . $selectors_handler->xpathLiteral($text) . ']';
+			$xpath = 'descendant-or-self::option[normalize-space(.) = ' . $this->getXpathEscaper()->escapeLiteral($text) . ']';
 		}
 		else {
-			$xpath = 'descendant-or-self::option[contains(., ' . $selectors_handler->xpathLiteral($text) . ')]';
+			$xpath = 'descendant-or-self::option[contains(., ' . $this->getXpathEscaper()->escapeLiteral($text) . ')]';
 		}
 
 		return $this->wrapOptions($this->getWrappedElement()->findAll('xpath', $xpath));

--- a/library/QATools/QATools/PageObject/Element/WebElement.php
+++ b/library/QATools/QATools/PageObject/Element/WebElement.php
@@ -11,6 +11,7 @@
 namespace QATools\QATools\PageObject\Element;
 
 
+use Behat\Mink\Selector\Xpath\Escaper;
 use QATools\QATools\PageObject\IPageFactory;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
@@ -29,7 +30,14 @@ class WebElement extends NodeElement implements IWebElement, INodeElementAware
 	 *
 	 * @var array
 	 */
-	protected $seleniumSelector;
+	private $_seleniumSelector;
+
+	/**
+	 * The XPath escaper.
+	 *
+	 * @var Escaper
+	 */
+	private $_xpathEscaper;
 
 	/**
 	 * Initializes web element.
@@ -39,7 +47,9 @@ class WebElement extends NodeElement implements IWebElement, INodeElementAware
 	 */
 	public function __construct(array $selenium_selector, Session $session)
 	{
-		$this->seleniumSelector = $selenium_selector;
+		$this->_seleniumSelector = $selenium_selector;
+
+		$this->_xpathEscaper = new Escaper();
 
 		parent::__construct($this->seleniumSelectorToXpath($session), $session);
 	}
@@ -68,7 +78,17 @@ class WebElement extends NodeElement implements IWebElement, INodeElementAware
 	 */
 	protected function seleniumSelectorToXpath(Session $session)
 	{
-		return $session->getSelectorsHandler()->selectorToXpath('se', $this->seleniumSelector);
+		return $session->getSelectorsHandler()->selectorToXpath('se', $this->_seleniumSelector);
+	}
+
+	/**
+	 * Get the XPath escaper.
+	 *
+	 * @return Escaper
+	 */
+	public function getXpathEscaper()
+	{
+		return $this->_xpathEscaper;
 	}
 
 	/**

--- a/library/QATools/QATools/PageObject/SeleniumSelector.php
+++ b/library/QATools/QATools/PageObject/SeleniumSelector.php
@@ -13,6 +13,7 @@ namespace QATools\QATools\PageObject;
 
 use Behat\Mink\Selector\SelectorInterface;
 use Behat\Mink\Selector\SelectorsHandler;
+use Behat\Mink\Selector\Xpath\Escaper;
 use QATools\QATools\PageObject\Exception\ElementException;
 
 /**
@@ -33,6 +34,13 @@ class SeleniumSelector implements SelectorInterface
 	private $_handler;
 
 	/**
+	 * The XPath escaper.
+	 *
+	 * @var Escaper
+	 */
+	private $_xpathEscaper;
+
+	/**
 	 * Creates instance of SeleniumSelector class.
 	 *
 	 * @param SelectorsHandler $selectors_handler Mink selectors handler.
@@ -40,6 +48,8 @@ class SeleniumSelector implements SelectorInterface
 	public function __construct(SelectorsHandler $selectors_handler)
 	{
 		$this->_handler = $selectors_handler;
+
+		$this->_xpathEscaper = new Escaper();
 	}
 
 	/**
@@ -63,7 +73,7 @@ class SeleniumSelector implements SelectorInterface
 		$locator = trim($locator);
 
 		if ( $selector == How::CLASS_NAME ) {
-			$locator = $this->_handler->xpathLiteral(' ' . $locator . ' ');
+			$locator = $this->_xpathEscaper->escapeLiteral(' ' . $locator . ' ');
 
 			return "descendant-or-self::*[@class and contains(concat(' ', normalize-space(@class), ' '), " . $locator . ')]';
 		}
@@ -71,13 +81,13 @@ class SeleniumSelector implements SelectorInterface
 			return $this->_handler->selectorToXpath('css', $locator);
 		}
 		elseif ( $selector == How::ID ) {
-			return 'descendant-or-self::*[@id = ' . $this->_handler->xpathLiteral($locator) . ']';
+			return 'descendant-or-self::*[@id = ' . $this->_xpathEscaper->escapeLiteral($locator) . ']';
 		}
 		elseif ( $selector == How::NAME ) {
-			return 'descendant-or-self::*[@name = ' . $this->_handler->xpathLiteral($locator) . ']';
+			return 'descendant-or-self::*[@name = ' . $this->_xpathEscaper->escapeLiteral($locator) . ']';
 		}
 		elseif ( $selector == How::ID_OR_NAME ) {
-			$locator = $this->_handler->xpathLiteral($locator);
+			$locator = $this->_xpathEscaper->escapeLiteral($locator);
 
 			return 'descendant-or-self::*[@id = ' . $locator . ' or @name = ' . $locator . ']';
 		}
@@ -85,12 +95,12 @@ class SeleniumSelector implements SelectorInterface
 			return 'descendant-or-self::' . $locator;
 		}
 		elseif ( $selector == How::LINK_TEXT ) {
-			$locator = $this->_handler->xpathLiteral($locator);
+			$locator = $this->_xpathEscaper->escapeLiteral($locator);
 
 			return 'descendant-or-self::a[./@href][normalize-space(string(.)) = ' . $locator . ']';
 		}
 		elseif ( $selector == How::LABEL ) {
-			$locator = $this->_handler->xpathLiteral($locator);
+			$locator = $this->_xpathEscaper->escapeLiteral($locator);
 			$xpath_pieces = array();
 			$xpath_pieces[] = 'descendant-or-self::*[@id = (//label[normalize-space(string(.)) = ' . $locator . ']/@for)]';
 			$xpath_pieces[] = 'descendant-or-self::label[normalize-space(string(.)) = ' . $locator . ']//input';
@@ -98,7 +108,7 @@ class SeleniumSelector implements SelectorInterface
 			return implode('|', $xpath_pieces);
 		}
 		elseif ( $selector == How::PARTIAL_LINK_TEXT ) {
-			$locator = $this->_handler->xpathLiteral($locator);
+			$locator = $this->_xpathEscaper->escapeLiteral($locator);
 
 			return 'descendant-or-self::a[./@href][contains(normalize-space(string(.)), ' . $locator . ')]';
 		}

--- a/tests/QATools/QATools/HtmlElements/Element/AbstractTypifiedElementTest.php
+++ b/tests/QATools/QATools/HtmlElements/Element/AbstractTypifiedElementTest.php
@@ -11,6 +11,7 @@
 namespace tests\QATools\QATools\HtmlElements\Element;
 
 
+use Behat\Mink\Selector\Xpath\Escaper;
 use Mockery as m;
 use QATools\QATools\HtmlElements\Element\AbstractTypifiedElement;
 use QATools\QATools\PageObject\Element\WebElement;
@@ -63,9 +64,18 @@ class AbstractTypifiedElementTest extends TestCase
 	 */
 	protected $expectedAttributes = array();
 
+	/**
+	 * Mocked XPATH escaper.
+	 *
+	 * @var Escaper
+	 */
+	protected $escaper;
+
 	protected function setUp()
 	{
 		parent::setUp();
+
+		$this->escaper = m::mock('Behat\\Mink\\Selector\\Xpath\\Escaper');
 
 		if ( is_null($this->elementClass) ) {
 			$this->elementClass = '\\tests\\QATools\\QATools\\HtmlElements\\Fixture\\Element\\TypifiedElementChild';
@@ -73,6 +83,7 @@ class AbstractTypifiedElementTest extends TestCase
 
 		$this->webElement = m::mock(self::WEB_ELEMENT_CLASS);
 		$this->webElement->shouldReceive('getSession')->withNoArgs()->andReturn($this->session);
+		$this->webElement->shouldReceive('getXpathEscaper')->withNoArgs()->andReturn($this->escaper);
 
 		if ( !in_array($this->getName(false), $this->ignoreExpectTypifiedNodeCheck) ) {
 			$this->expectWebElementGetTagName($this->expectedTagName);

--- a/tests/QATools/QATools/HtmlElements/Element/FormTest.php
+++ b/tests/QATools/QATools/HtmlElements/Element/FormTest.php
@@ -68,22 +68,15 @@ class FormTest extends AbstractElementContainerTest
 	 */
 	public function testGetNodeElementsFailure()
 	{
-		if ( method_exists($this->selectorsHandler, 'xpathLiteral') ) {
-			$this->selectorsHandler->shouldReceive('xpathLiteral')
-				->with('field-name')
-				->once()
-				->andReturn("'field-name'");
-			$this->webElement->shouldReceive('findAll')
-				->with('named', array('field', "'field-name'"))
-				->once()
-				->andReturn(array());
-		}
-		else {
-			$this->webElement->shouldReceive('findAll')
-				->with('named', array('field', 'field-name'))
-				->once()
-				->andReturn(array());
-		}
+		$this->escaper->shouldReceive('escapeLiteral')
+			->with('field-name')
+			->once()
+			->andReturn("'field-name'");
+
+		$this->webElement->shouldReceive('findAll')
+			->with('named', array('field', "'field-name'"))
+			->once()
+			->andReturn(array());
 
 		$this->getElement()->getNodeElements('field-name');
 	}
@@ -92,25 +85,16 @@ class FormTest extends AbstractElementContainerTest
 	{
 		$node_elements = array($this->createNodeElement());
 
-		if ( method_exists($this->selectorsHandler, 'xpathLiteral') ) {
-			$this->selectorsHandler->shouldReceive('xpathLiteral')
-				->with('field-name')
-				->once()
-				->andReturn("'field-name'");
+		$this->escaper->shouldReceive('escapeLiteral')
+			->with('field-name')
+			->once()
+			->andReturn("'field-name'");
 
-			$this->webElement
-				->shouldReceive('findAll')
-				->with('named', array('field', "'field-name'"))
-				->once()
-				->andReturn($node_elements);
-		}
-		else {
-			$this->webElement
-				->shouldReceive('findAll')
-				->with('named', array('field', 'field-name'))
-				->once()
-				->andReturn($node_elements);
-		}
+		$this->webElement
+			->shouldReceive('findAll')
+			->with('named', array('field', "'field-name'"))
+			->once()
+			->andReturn($node_elements);
 
 		$found_elements = $this->getElement()->getNodeElements('field-name');
 

--- a/tests/QATools/QATools/HtmlElements/Element/LabeledElementTest.php
+++ b/tests/QATools/QATools/HtmlElements/Element/LabeledElementTest.php
@@ -41,7 +41,7 @@ class LabeledElementTest extends AbstractTypifiedElementTest
 			->once()
 			->andReturn('FOUND1');
 
-		$this->selectorsHandler->shouldReceive('xpathLiteral')->with('ID_VALUE')->andReturn('ID_VALUE_ESCAPED');
+		$this->escaper->shouldReceive('escapeLiteral')->with('ID_VALUE')->andReturn('ID_VALUE_ESCAPED');
 
 		$this->assertEquals('FOUND1', $this->getElement()->getLabel());
 	}

--- a/tests/QATools/QATools/HtmlElements/Element/SelectTest.php
+++ b/tests/QATools/QATools/HtmlElements/Element/SelectTest.php
@@ -80,7 +80,7 @@ class SelectTest extends AbstractTypifiedElementTest
 	{
 		$this->expectDriverGetTagName('option');
 
-		$this->selectorsHandler->shouldReceive('xpathLiteral')->with('SV')->andReturn('SV');
+		$this->escaper->shouldReceive('escapeLiteral')->with('SV')->andReturn('SV');
 
 		$this->webElement
 			->shouldReceive('findAll')
@@ -102,7 +102,7 @@ class SelectTest extends AbstractTypifiedElementTest
 	{
 		$this->expectDriverGetTagName('option');
 
-		$this->selectorsHandler->shouldReceive('xpathLiteral')->with('SV')->andReturn('SV');
+		$this->escaper->shouldReceive('escapeLiteral')->with('SV')->andReturn('SV');
 
 		if ( $exact_match ) {
 			$xpath = 'descendant-or-self::option[normalize-space(.) = SV]';


### PR DESCRIPTION
Based on #115 using the `Escaper` wherever required, adding it to the `PageFactory` would have had too big impact.

Closes #115.