### PR TITLE
The "Url\Parser::merge" now combines "path" and "query" components of merged urls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,8 @@ before_script:
     - mkdir -p build/logs
 
 script:
-    - if [ "$TRAVIS_PHP_VERSION" = "7" ]; then phpunit --coverage-clover build/logs/clover.xml; fi;
-    - if [ "$TRAVIS_PHP_VERSION" != "7" ]; then ./vendor/bin/paratest --coverage-clover build/logs/clover.xml; fi;
+    - if [ "$TRAVIS_PHP_VERSION" = "7" -o "$TRAVIS_PHP_VERSION" == "hhvm" ]; then phpunit --coverage-clover build/logs/clover.xml; fi;
+    - if [ "$TRAVIS_PHP_VERSION" != "7" -a "$TRAVIS_PHP_VERSION" != "hhvm" ]; then ./vendor/bin/paratest --coverage-clover build/logs/clover.xml; fi;
 
 after_script:
     - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php vendor/bin/coveralls -v; fi;

--- a/library/QATools/QATools/PageObject/Url/Parser.php
+++ b/library/QATools/QATools/PageObject/Url/Parser.php
@@ -109,7 +109,23 @@ class Parser
 	 */
 	public function merge(Parser $parser)
 	{
+		$left_path = $this->getComponent('path');
+		$right_path = $parser->getComponent('path');
+
+		$left_params = $this->getParams();
+		$right_params = $parser->getParams();
+
 		$this->components = array_merge($this->components, $parser->components);
+
+		if ( $left_path && $right_path ) {
+			$this->components['path'] = rtrim($left_path, '/') . '/' . ltrim($right_path, '/');
+		}
+
+		if ( $left_params && $right_params ) {
+			$this->components['query'] = http_build_query(
+				array_replace_recursive($left_params, $right_params)
+			);
+		}
 
 		return $this;
 	}

--- a/tests/QATools/QATools/PageObject/Url/NormalizerTest.php
+++ b/tests/QATools/QATools/PageObject/Url/NormalizerTest.php
@@ -37,11 +37,13 @@ class NormalizerTest extends TestCase
 		$this->assertEquals($expected_normalized_components, $normalizer->normalize($page_url_annotation));
 	}
 
+	/**
+	 * @see ParserTest::mergeDataProvider
+	 */
 	public function normalizeDataProvider()
 	{
 		return array(
-			// Missing base url.
-			array(
+			'missing base url' => array(
 				'',
 				'http://domain.tld/path?param=value#anchor',
 				null,
@@ -53,8 +55,7 @@ class NormalizerTest extends TestCase
 					'fragment' => 'anchor',
 				),
 			),
-			// Defined base url.
-			array(
+			'defined base url' => array(
 				'http://base.tld',
 				'/path?param=value#anchor',
 				null,
@@ -66,8 +67,7 @@ class NormalizerTest extends TestCase
 					'fragment' => 'anchor',
 				),
 			),
-			// Defined secure mode.
-			array(
+			'secure mode enabled' => array(
 				'http://base.tld',
 				'/path?param=value#anchor',
 				true,
@@ -79,7 +79,7 @@ class NormalizerTest extends TestCase
 					'fragment' => 'anchor',
 				),
 			),
-			array(
+			'secure mode disabled' => array(
 				'https://base.tld',
 				'/path?param=value#anchor',
 				false,
@@ -91,15 +91,14 @@ class NormalizerTest extends TestCase
 					'fragment' => 'anchor',
 				),
 			),
-			// Merge priority.
-			array(
+			'merge priority' => array(
 				'http://base.tld/path',
 				'https://another.tld/path2?param=value#anchor',
 				null,
 				array(
 					'scheme' => 'https',
 					'host' => 'another.tld',
-					'path' => '/path2',
+					'path' => '/path/path2',
 					'query' => 'param=value',
 					'fragment' => 'anchor',
 				),

--- a/tests/QATools/QATools/PageObject/Url/ParserTest.php
+++ b/tests/QATools/QATools/PageObject/Url/ParserTest.php
@@ -89,28 +89,135 @@ class ParserTest extends TestCase
 	/**
 	 * @dataProvider mergeDataProvider
 	 */
-	public function testMerge($first_url, $second_url, $expected_component, $expected_value)
+	public function testMerge($first_url, $second_url, array $expected_components)
 	{
 		$url_parser = new Parser($first_url);
 		$url_parser->merge(new Parser($second_url));
 
-		$this->assertEquals($expected_value, $url_parser->getComponent($expected_component));
+		foreach ( $expected_components as $expected_component => $expected_value ) {
+			$this->assertEquals(
+				$expected_value,
+				$url_parser->getComponent($expected_component),
+				'The "' . $expected_component . '" has expected value.'
+			);
+		}
 	}
 
 	public function mergeDataProvider()
 	{
 		return array(
-			array('http://domain.tld#anchor', '/path?param=value', 'scheme', 'http'),
-			array('http://domain.tld#anchor', '/path?param=value', 'host', 'domain.tld'),
-			array('http://domain.tld#anchor', '/path?param=value', 'path', '/path'),
-			array('http://domain.tld#anchor', '/path?param=value', 'query', 'param=value'),
-			array('http://domain.tld#anchor', '/path?param=value', 'fragment', 'anchor'),
-			// Test the priority on merge.
-			array('http://domain.tld/path#anchor', 'https://another.tld:8080/path2#anchor2', 'scheme', 'https'),
-			array('http://domain.tld/path#anchor', 'https://another.tld:8080/path2#anchor2', 'host', 'another.tld'),
-			array('http://domain.tld/path#anchor', 'https://another.tld:8080/path2#anchor2', 'path', '/path2'),
-			array('http://domain.tld/path#anchor', 'https://another.tld:8080/path2#anchor2', 'fragment', 'anchor2'),
-			array('http://domain.tld/path#anchor', 'https://another.tld:8080/path2#anchor2', 'port', 8080),
+			'absolute and absolute url' => array(
+				'http://user1:pass1@domain1:1111/folder1/?param1=value1#anchor1',
+				'https://user2:pass2@domain2:2222/folder2/?param2=value2#anchor2',
+				array(
+					'scheme' => 'https',
+					'host' => 'domain2',
+					'port' => 2222,
+					'user' => 'user2',
+					'pass' => 'pass2',
+					'path' => '/folder1/folder2/',
+					'query' => 'param1=value1&param2=value2',
+					'fragment' => 'anchor2',
+				),
+			),
+			'absolute and relative url' => array(
+				'http://user1:pass1@domain1:1111/folder1/?param1=value1#anchor1',
+				'/folder2/?param2=value2#anchor2',
+				array(
+					'scheme' => 'http',
+					'host' => 'domain1',
+					'port' => 1111,
+					'user' => 'user1',
+					'pass' => 'pass1',
+					'path' => '/folder1/folder2/',
+					'query' => 'param1=value1&param2=value2',
+					'fragment' => 'anchor2',
+				),
+			),
+			'relative and absolute url' => array(
+				'/folder1/?param1=value1#anchor1',
+				'https://user2:pass2@domain2:2222/folder2/?param2=value2#anchor2',
+				array(
+					'scheme' => 'https',
+					'host' => 'domain2',
+					'port' => 2222,
+					'user' => 'user2',
+					'pass' => 'pass2',
+					'path' => '/folder1/folder2/',
+					'query' => 'param1=value1&param2=value2',
+					'fragment' => 'anchor2',
+				),
+			),
+			'domain replacement' => array(
+				'http://user1:pass1@domain1:1111/folder1/?param1=value1#anchor1',
+				'https://domain2/folder2/?param2=value2#anchor2',
+				array(
+					'scheme' => 'https',
+					'host' => 'domain2',
+					'port' => 1111,
+					'user' => 'user1',
+					'pass' => 'pass1',
+					'path' => '/folder1/folder2/',
+					'query' => 'param1=value1&param2=value2',
+					'fragment' => 'anchor2',
+				),
+			),
+			'adding user, pass, port' => array(
+				'http://domain1/folder1/?param1=value1#anchor1',
+				'https://user2:pass2@domain1:2222/folder2/?param2=value2#anchor2',
+				array(
+					'scheme' => 'https',
+					'host' => 'domain1',
+					'port' => 2222,
+					'user' => 'user2',
+					'pass' => 'pass2',
+					'path' => '/folder1/folder2/',
+					'query' => 'param1=value1&param2=value2',
+					'fragment' => 'anchor2',
+				),
+			),
+			'relative and relative url' => array(
+				'/folder1/?param1=value1#anchor1',
+				'/folder2/?param2=value2#anchor2',
+				array(
+					'scheme' => '',
+					'host' => '',
+					'port' => '',
+					'user' => '',
+					'pass' => '',
+					'path' => '/folder1/folder2/',
+					'query' => 'param1=value1&param2=value2',
+					'fragment' => 'anchor2',
+				),
+			),
+			'query string param replace' => array(
+				'http://user1:pass1@domain1:1111/folder1/?param1=value1#anchor1',
+				'https://user2:pass2@domain2:2222/folder2/?param2=value2&param1=value3#anchor2',
+				array(
+					'scheme' => 'https',
+					'host' => 'domain2',
+					'port' => 2222,
+					'user' => 'user2',
+					'pass' => 'pass2',
+					'path' => '/folder1/folder2/',
+					'query' => 'param1=value3&param2=value2',
+					'fragment' => 'anchor2',
+				),
+			),
+			'nested query string param replace' => array(
+				'http://user1:pass1@domain1:1111/folder1/?param1[key1]=value1&param1[key2]=value2#anchor1',
+				'https://user2:pass2@domain2:2222/folder2/?param2=value2&param1[key1]=value3#anchor2',
+				array(
+					'scheme' => 'https',
+					'host' => 'domain2',
+					'port' => 2222,
+					'user' => 'user2',
+					'pass' => 'pass2',
+					'path' => '/folder1/folder2/',
+					'query' => 'param1%5Bkey1%5D=value3&param1%5Bkey2%5D=value2&param2=value2',
+					'fragment' => 'anchor2',
+				),
+			),
 		);
 	}
 

--- a/tests/QATools/QATools/PageObject/Url/ParserTest.php
+++ b/tests/QATools/QATools/PageObject/Url/ParserTest.php
@@ -103,6 +103,9 @@ class ParserTest extends TestCase
 		}
 	}
 
+	/**
+	 * @see NormalizerTest::normalizeDataProvider
+	 */
 	public function mergeDataProvider()
 	{
 		return array(


### PR DESCRIPTION
Also fixed failing HHVM build (see https://github.com/brianium/paratest/issues/66) by using PHPUnit directly instead of via ParaTest.

Closes #141