### PR TITLE
Add image inputs to button acceptance criteria

### DIFF
--- a/library/QATools/QATools/HtmlElements/Element/Button.php
+++ b/library/QATools/QATools/HtmlElements/Element/Button.php
@@ -23,7 +23,7 @@ class Button extends AbstractTypifiedElement
 	 * @var array
 	 */
 	protected $acceptanceCriteria = array(
-		array('tag' => 'input', 'attrs' => array('type' => 'submit|button')),
+		array('tag' => 'input', 'attrs' => array('type' => 'submit|button|image')),
 		array('tag' => 'button'),
 		array('attrs' => array('role' => 'button')),
 	);


### PR DESCRIPTION
Inputs with a type of "image" can also be used to submit forms. This PR just opens up the acceptance criteria to allow this.

Didn't think this was worthy of a changelog entry as per contributing, but I can add one if wanted?