### PR TITLE
Remove "AnnotationManager" from the "DefaultElementLocator"

### DIFF
--- a/library/QATools/QATools/BEM/ElementLocator/BEMElementLocator.php
+++ b/library/QATools/QATools/BEM/ElementLocator/BEMElementLocator.php
@@ -11,7 +11,6 @@
 namespace QATools\QATools\BEM\ElementLocator;
 
 
-use mindplay\annotations\AnnotationManager;
 use QATools\QATools\BEM\Annotation\BEMAnnotation;
 use QATools\QATools\BEM\Element\IBlock;
 use QATools\QATools\PageObject\ElementLocator\DefaultElementLocator;
@@ -37,18 +36,16 @@ class BEMElementLocator extends DefaultElementLocator
 	/**
 	 * Creates a new element locator.
 	 *
-	 * @param Property          $property           Property.
-	 * @param ISearchContext    $search_context     The context to use when finding the element.
-	 * @param AnnotationManager $annotation_manager Annotation manager.
-	 * @param LocatorHelper     $locator_helper     Locator helper.
+	 * @param Property       $property       Property.
+	 * @param ISearchContext $search_context The context to use when finding the element.
+	 * @param LocatorHelper  $locator_helper Locator helper.
 	 */
 	public function __construct(
 		Property $property,
 		ISearchContext $search_context,
-		AnnotationManager $annotation_manager,
 		LocatorHelper $locator_helper
 	) {
-		parent::__construct($property, $search_context, $annotation_manager);
+		parent::__construct($property, $search_context);
 
 		$this->_helper = $locator_helper;
 	}

--- a/library/QATools/QATools/BEM/ElementLocator/BEMElementLocatorFactory.php
+++ b/library/QATools/QATools/BEM/ElementLocator/BEMElementLocatorFactory.php
@@ -57,7 +57,7 @@ class BEMElementLocatorFactory extends DefaultElementLocatorFactory
 	 */
 	public function createLocator(Property $property)
 	{
-		return new BEMElementLocator($property, $this->searchContext, $this->annotationManager, $this->_locatorHelper);
+		return new BEMElementLocator($property, $this->searchContext, $this->_locatorHelper);
 	}
 
 }

--- a/library/QATools/QATools/PageObject/ElementLocator/DefaultElementLocator.php
+++ b/library/QATools/QATools/PageObject/ElementLocator/DefaultElementLocator.php
@@ -12,7 +12,6 @@ namespace QATools\QATools\PageObject\ElementLocator;
 
 
 use Behat\Mink\Element\NodeElement;
-use mindplay\annotations\AnnotationManager;
 use QATools\QATools\PageObject\Annotation\FindByAnnotation;
 use QATools\QATools\PageObject\Exception\AnnotationException;
 use QATools\QATools\PageObject\Exception\ElementException;
@@ -35,13 +34,6 @@ class DefaultElementLocator implements IElementLocator
 	protected $searchContext;
 
 	/**
-	 * Annotation manager.
-	 *
-	 * @var AnnotationManager
-	 */
-	protected $annotationManager;
-
-	/**
 	 * Property.
 	 *
 	 * @var Property
@@ -51,18 +43,13 @@ class DefaultElementLocator implements IElementLocator
 	/**
 	 * Creates a new element locator.
 	 *
-	 * @param Property          $property           Property.
-	 * @param ISearchContext    $search_context     The context to use when finding the element.
-	 * @param AnnotationManager $annotation_manager Annotation manager.
+	 * @param Property       $property       Property.
+	 * @param ISearchContext $search_context The context to use when finding the element.
 	 */
-	public function __construct(
-		Property $property,
-		ISearchContext $search_context,
-		AnnotationManager $annotation_manager
-	) {
+	public function __construct(Property $property, ISearchContext $search_context)
+	{
 		$this->property = $property;
 		$this->searchContext = $search_context;
-		$this->annotationManager = $annotation_manager;
 	}
 
 	/**

--- a/library/QATools/QATools/PageObject/ElementLocator/DefaultElementLocatorFactory.php
+++ b/library/QATools/QATools/PageObject/ElementLocator/DefaultElementLocatorFactory.php
@@ -58,7 +58,7 @@ class DefaultElementLocatorFactory implements IElementLocatorFactory
 	 */
 	public function createLocator(Property $property)
 	{
-		return new WaitingElementLocator($property, $this->searchContext, $this->annotationManager);
+		return new WaitingElementLocator($property, $this->searchContext);
 	}
 
 }

--- a/library/QATools/QATools/PageObject/ElementLocator/WaitingElementLocator.php
+++ b/library/QATools/QATools/PageObject/ElementLocator/WaitingElementLocator.php
@@ -12,7 +12,6 @@ namespace QATools\QATools\PageObject\ElementLocator;
 
 
 use Behat\Mink\Element\NodeElement;
-use mindplay\annotations\AnnotationManager;
 use QATools\QATools\PageObject\Annotation\TimeoutAnnotation;
 use QATools\QATools\PageObject\ISearchContext;
 use QATools\QATools\PageObject\Property;
@@ -35,16 +34,12 @@ class WaitingElementLocator extends DefaultElementLocator
 	/**
 	 * Creates a new element locator.
 	 *
-	 * @param Property          $property           Property.
-	 * @param ISearchContext    $search_context     The context to use when finding the element.
-	 * @param AnnotationManager $annotation_manager Annotation manager.
+	 * @param Property       $property       Property.
+	 * @param ISearchContext $search_context The context to use when finding the element.
 	 */
-	public function __construct(
-		Property $property,
-		ISearchContext $search_context,
-		AnnotationManager $annotation_manager
-	) {
-		parent::__construct($property, $search_context, $annotation_manager);
+	public function __construct(Property $property, ISearchContext $search_context)
+	{
+		parent::__construct($property, $search_context);
 
 		/** @var TimeoutAnnotation[] $annotations */
 		$annotations = $property->getAnnotationsFromPropertyOrClass('@timeout');

--- a/tests/QATools/QATools/BEM/ElementLocator/BEMElementLocatorTest.php
+++ b/tests/QATools/QATools/BEM/ElementLocator/BEMElementLocatorTest.php
@@ -208,14 +208,13 @@ class BEMElementLocatorTest extends DefaultElementLocatorTest
 
 			return m::mock(
 				$class,
-				array($this->property, $this->searchContext, $this->annotationManager, $this->_locatorHelper)
+				array($this->property, $this->searchContext, $this->_locatorHelper)
 			);
 		}
 
 		return new $this->locatorClass(
 			$this->property,
 			$this->searchContext,
-			$this->annotationManager,
 			$this->_locatorHelper
 		);
 	}

--- a/tests/QATools/QATools/PageObject/ElementLocator/DefaultElementLocatorTest.php
+++ b/tests/QATools/QATools/PageObject/ElementLocator/DefaultElementLocatorTest.php
@@ -50,13 +50,6 @@ class DefaultElementLocatorTest extends TestCase
 	protected $property;
 
 	/**
-	 * Annotation manager.
-	 *
-	 * @var \Mockery\MockInterface
-	 */
-	protected $annotationManager;
-
-	/**
 	 * Search context.
 	 *
 	 * @var \Mockery\MockInterface
@@ -76,7 +69,6 @@ class DefaultElementLocatorTest extends TestCase
 	protected function setUpTest()
 	{
 		$this->property = m::mock(self::PROPERTY_CLASS);
-		$this->annotationManager = m::mock('\\mindplay\\annotations\\AnnotationManager');
 		$this->searchContext = m::mock($this->searchContextClass);
 
 		$this->locator = $this->createLocator();
@@ -220,10 +212,10 @@ class DefaultElementLocatorTest extends TestCase
 		if ( $mock_methods ) {
 			$class = $this->locatorClass . '[' . implode(',', $mock_methods) . ']';
 
-			return m::mock($class, array($this->property, $this->searchContext, $this->annotationManager));
+			return m::mock($class, array($this->property, $this->searchContext));
 		}
 
-		return new $this->locatorClass($this->property, $this->searchContext, $this->annotationManager);
+		return new $this->locatorClass($this->property, $this->searchContext);
 	}
 
 }


### PR DESCRIPTION
The `AnnotationManager` was given to the `DefaultElementLocator`, but was never used by a later.