### PR TITLE
Remove "AnnotationManager" from the "DefaultElementLocatorFactory"

### DIFF
--- a/library/QATools/QATools/BEM/BEMPageFactory.php
+++ b/library/QATools/QATools/BEM/BEMPageFactory.php
@@ -60,11 +60,7 @@ class BEMPageFactory extends PageFactory
 	 */
 	public function createDecorator(ISearchContext $search_context)
 	{
-		$locator_factory = new BEMElementLocatorFactory(
-			$search_context,
-			$this->annotationManager,
-			$this->_locatorHelper
-		);
+		$locator_factory = new BEMElementLocatorFactory($search_context, $this->_locatorHelper);
 
 		return new BEMPropertyDecorator($locator_factory, $this);
 	}

--- a/library/QATools/QATools/BEM/ElementLocator/BEMElementLocatorFactory.php
+++ b/library/QATools/QATools/BEM/ElementLocator/BEMElementLocatorFactory.php
@@ -15,7 +15,6 @@ use QATools\QATools\PageObject\ElementLocator\DefaultElementLocatorFactory;
 use QATools\QATools\PageObject\ElementLocator\IElementLocator;
 use QATools\QATools\PageObject\ISearchContext;
 use QATools\QATools\PageObject\Property;
-use mindplay\annotations\AnnotationManager;
 
 /**
  * Factory to create BEM block/element locators.
@@ -35,16 +34,14 @@ class BEMElementLocatorFactory extends DefaultElementLocatorFactory
 	/**
 	 * Create locator factory instance.
 	 *
-	 * @param ISearchContext    $search_context     Search context.
-	 * @param AnnotationManager $annotation_manager Annotation manager.
-	 * @param LocatorHelper     $locator_helper     Locator helper.
+	 * @param ISearchContext $search_context Search context.
+	 * @param LocatorHelper  $locator_helper Locator helper.
 	 */
 	public function __construct(
 		ISearchContext $search_context,
-		AnnotationManager $annotation_manager,
 		LocatorHelper $locator_helper
 	) {
-		parent::__construct($search_context, $annotation_manager);
+		parent::__construct($search_context);
 		$this->_locatorHelper = $locator_helper;
 	}
 

--- a/library/QATools/QATools/HtmlElements/TypifiedPageFactory.php
+++ b/library/QATools/QATools/HtmlElements/TypifiedPageFactory.php
@@ -49,7 +49,7 @@ class TypifiedPageFactory extends PageFactory
 	 */
 	public function createDecorator(ISearchContext $search_context)
 	{
-		$locator_factory = new DefaultElementLocatorFactory($search_context, $this->annotationManager);
+		$locator_factory = new DefaultElementLocatorFactory($search_context);
 
 		return new TypifiedPropertyDecorator($locator_factory, $this);
 	}

--- a/library/QATools/QATools/PageObject/ElementLocator/DefaultElementLocatorFactory.php
+++ b/library/QATools/QATools/PageObject/ElementLocator/DefaultElementLocatorFactory.php
@@ -11,7 +11,6 @@
 namespace QATools\QATools\PageObject\ElementLocator;
 
 
-use mindplay\annotations\AnnotationManager;
 use QATools\QATools\PageObject\ISearchContext;
 use QATools\QATools\PageObject\Property;
 
@@ -31,22 +30,13 @@ class DefaultElementLocatorFactory implements IElementLocatorFactory
 	protected $searchContext;
 
 	/**
-	 * Page factory.
-	 *
-	 * @var AnnotationManager
-	 */
-	protected $annotationManager;
-
-	/**
 	 * Create locator factory instance.
 	 *
-	 * @param ISearchContext    $search_context     Search context.
-	 * @param AnnotationManager $annotation_manager Annotation manager.
+	 * @param ISearchContext $search_context Search context.
 	 */
-	public function __construct(ISearchContext $search_context, AnnotationManager $annotation_manager)
+	public function __construct(ISearchContext $search_context)
 	{
 		$this->searchContext = $search_context;
-		$this->annotationManager = $annotation_manager;
 	}
 
 	/**

--- a/library/QATools/QATools/PageObject/PageFactory.php
+++ b/library/QATools/QATools/PageObject/PageFactory.php
@@ -173,7 +173,7 @@ class PageFactory implements IPageFactory
 	 */
 	public function createDecorator(ISearchContext $search_context)
 	{
-		$locator_factory = new DefaultElementLocatorFactory($search_context, $this->annotationManager);
+		$locator_factory = new DefaultElementLocatorFactory($search_context);
 
 		return new DefaultPropertyDecorator($locator_factory, $this);
 	}

--- a/tests/QATools/QATools/BEM/ElementLocator/BEMElementLocatorFactoryTest.php
+++ b/tests/QATools/QATools/BEM/ElementLocator/BEMElementLocatorFactoryTest.php
@@ -32,10 +32,9 @@ class BEMElementLocatorFactoryTest extends TestCase
 
 	public function testCreateLocator()
 	{
-		$annotation_manager = m::mock('\\mindplay\\annotations\\AnnotationManager');
 		$search_context = m::mock('\\QATools\\QATools\\PageObject\\ISearchContext');
 		$locator_helper = m::mock('\\QATools\\QATools\\BEM\\ElementLocator\\LocatorHelper');
-		$factory = new BEMElementLocatorFactory($search_context, $annotation_manager, $locator_helper);
+		$factory = new BEMElementLocatorFactory($search_context, $locator_helper);
 
 		$property = m::mock(self::PROPERTY_CLASS);
 		$locator = $factory->createLocator($property);

--- a/tests/QATools/QATools/PageObject/ElementLocator/DefaultElementLocatorFactoryTest.php
+++ b/tests/QATools/QATools/PageObject/ElementLocator/DefaultElementLocatorFactoryTest.php
@@ -32,9 +32,8 @@ class DefaultElementLocatorFactoryTest extends TestCase
 
 	public function testCreateLocator()
 	{
-		$annotation_manager = m::mock('\\mindplay\\annotations\\AnnotationManager');
 		$search_context = m::mock('\\QATools\\QATools\\PageObject\\ISearchContext');
-		$factory = new DefaultElementLocatorFactory($search_context, $annotation_manager);
+		$factory = new DefaultElementLocatorFactory($search_context);
 
 		$property = m::mock(self::PROPERTY_CLASS);
 		$property->shouldReceive('getAnnotationsFromPropertyOrClass')->with('@timeout')->once()->andReturn(array());

--- a/tests/QATools/QATools/PageObject/PropertyDecorator/DefaultPropertyDecoratorTest.php
+++ b/tests/QATools/QATools/PageObject/PropertyDecorator/DefaultPropertyDecoratorTest.php
@@ -243,7 +243,7 @@ class DefaultPropertyDecoratorTest extends TestCase
 
 		/** @var $page_factory IPageFactory */
 		$page_factory = m::mock('\\QATools\\QATools\\PageObject\\IPageFactory');
-		$locator_factory = new DefaultElementLocatorFactory($search_context, $annotation_manager);
+		$locator_factory = new DefaultElementLocatorFactory($search_context);
 
 		/** @var $decorator IPropertyDecorator */
 		$decorator = new $this->decoratorClass($locator_factory, $page_factory);


### PR DESCRIPTION
The `AnnotationManager` was given to the `DefaultElementLocatorFactory`, but was never used by a later.