### PR TITLE
Change Selenium Selector resolution principle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - The `WebElement::waitFor` method now provide `WebElement` class (or used subclass, like `AbstractElementContainer`, etc.) instance to the callback instead of a Mink's `NodeElement` class instance.
 - The `Page::waitFor` method now provide `Page` class (or used subclass, like `TypifiedPage`, `BEMPage`, etc.) instance to the callback instead of a Mink's `DocumentElement` class instance.
+- The `se` selector handler is no longer registered in the Mink Session (use the `PageFactory::translateToXPath` instead).
 
 ### Fixed
 ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added the public `Page::getBrowserUrl` method, that returns URL of the Web Browser (overriding allows operating within a frameset).
 - Added the protected `Page::setBrowserUrl` method, that sets URL of the Web Browser (overriding allows operating within a frameset).
+- Added the public `PageFactory::translateToXPath` method for converting Selenium-style selector (how + using) into XPath.
 
 ### Changed
 - The `WebElement::waitFor` method now provide `WebElement` class (or used subclass, like `AbstractElementContainer`, etc.) instance to the callback instead of a Mink's `NodeElement` class instance.

--- a/library/QATools/QATools/BEM/BEMPageFactory.php
+++ b/library/QATools/QATools/BEM/BEMPageFactory.php
@@ -60,7 +60,11 @@ class BEMPageFactory extends PageFactory
 	 */
 	public function createDecorator(ISearchContext $search_context)
 	{
-		$locator_factory = new BEMElementLocatorFactory($search_context, $this->_locatorHelper);
+		$locator_factory = new BEMElementLocatorFactory(
+			$search_context,
+			$this->seleniumSelector,
+			$this->_locatorHelper
+		);
 
 		return new BEMPropertyDecorator($locator_factory, $this);
 	}

--- a/library/QATools/QATools/BEM/Element/Block.php
+++ b/library/QATools/QATools/BEM/Element/Block.php
@@ -38,6 +38,13 @@ class Block extends AbstractPart implements IBlock
 	private $_locator;
 
 	/**
+	 * Page factory.
+	 *
+	 * @var IPageFactory
+	 */
+	private $_pageFactory;
+
+	/**
 	 * Create instance of BEM block.
 	 *
 	 * @param string              $name         Block name.
@@ -51,6 +58,7 @@ class Block extends AbstractPart implements IBlock
 
 		$this->_nodes = $nodes;
 		$this->_locator = $locator;
+		$this->_pageFactory = $page_factory;
 
 		$page_factory->initElements($this, $page_factory->createDecorator($this));
 	}
@@ -99,7 +107,11 @@ class Block extends AbstractPart implements IBlock
 			$modificator_value
 		);
 
-		return $this->findAll('se', $locator);
+		$how = key($locator);
+		$using = $locator[$how];
+		$xpath = $this->_pageFactory->translateToXPath($how, $using);
+
+		return $this->findAll('xpath', $xpath);
 	}
 
 	/**

--- a/library/QATools/QATools/BEM/ElementLocator/BEMElementLocator.php
+++ b/library/QATools/QATools/BEM/ElementLocator/BEMElementLocator.php
@@ -17,6 +17,7 @@ use QATools\QATools\PageObject\ElementLocator\DefaultElementLocator;
 use QATools\QATools\PageObject\Exception\AnnotationException;
 use QATools\QATools\PageObject\ISearchContext;
 use QATools\QATools\PageObject\Property;
+use QATools\QATools\PageObject\SeleniumSelector;
 
 /**
  * Locates BEM blocks/elements.
@@ -36,16 +37,18 @@ class BEMElementLocator extends DefaultElementLocator
 	/**
 	 * Creates a new element locator.
 	 *
-	 * @param Property       $property       Property.
-	 * @param ISearchContext $search_context The context to use when finding the element.
-	 * @param LocatorHelper  $locator_helper Locator helper.
+	 * @param Property         $property          Property.
+	 * @param ISearchContext   $search_context    The context to use when finding the element.
+	 * @param SeleniumSelector $selenium_selector Selenium selector.
+	 * @param LocatorHelper    $locator_helper    Locator helper.
 	 */
 	public function __construct(
 		Property $property,
 		ISearchContext $search_context,
+		SeleniumSelector $selenium_selector,
 		LocatorHelper $locator_helper
 	) {
-		parent::__construct($property, $search_context);
+		parent::__construct($property, $search_context, $selenium_selector);
 
 		$this->_helper = $locator_helper;
 	}

--- a/library/QATools/QATools/BEM/ElementLocator/BEMElementLocatorFactory.php
+++ b/library/QATools/QATools/BEM/ElementLocator/BEMElementLocatorFactory.php
@@ -15,6 +15,7 @@ use QATools\QATools\PageObject\ElementLocator\DefaultElementLocatorFactory;
 use QATools\QATools\PageObject\ElementLocator\IElementLocator;
 use QATools\QATools\PageObject\ISearchContext;
 use QATools\QATools\PageObject\Property;
+use QATools\QATools\PageObject\SeleniumSelector;
 
 /**
  * Factory to create BEM block/element locators.
@@ -34,14 +35,16 @@ class BEMElementLocatorFactory extends DefaultElementLocatorFactory
 	/**
 	 * Create locator factory instance.
 	 *
-	 * @param ISearchContext $search_context Search context.
-	 * @param LocatorHelper  $locator_helper Locator helper.
+	 * @param ISearchContext   $search_context    Search context.
+	 * @param SeleniumSelector $selenium_selector Selenium selector.
+	 * @param LocatorHelper    $locator_helper    Locator helper.
 	 */
 	public function __construct(
 		ISearchContext $search_context,
+		SeleniumSelector $selenium_selector,
 		LocatorHelper $locator_helper
 	) {
-		parent::__construct($search_context);
+		parent::__construct($search_context, $selenium_selector);
 		$this->_locatorHelper = $locator_helper;
 	}
 
@@ -54,7 +57,7 @@ class BEMElementLocatorFactory extends DefaultElementLocatorFactory
 	 */
 	public function createLocator(Property $property)
 	{
-		return new BEMElementLocator($property, $this->searchContext, $this->_locatorHelper);
+		return new BEMElementLocator($property, $this->searchContext, $this->seleniumSelector, $this->_locatorHelper);
 	}
 
 }

--- a/library/QATools/QATools/HtmlElements/Element/Select.php
+++ b/library/QATools/QATools/HtmlElements/Element/Select.php
@@ -47,7 +47,12 @@ class Select extends AbstractTypifiedElement implements ISimpleSetter
 	 */
 	public function getOptions()
 	{
-		return $this->wrapOptions($this->getWrappedElement()->findAll('se', array(How::TAG_NAME => 'option')));
+		return $this->wrapOptions(
+			$this->getWrappedElement()->findAll(
+				'xpath',
+				$this->getPageFactory()->translateToXPath(How::TAG_NAME, 'option')
+			)
+		);
 	}
 
 	/**

--- a/library/QATools/QATools/HtmlElements/TypifiedPageFactory.php
+++ b/library/QATools/QATools/HtmlElements/TypifiedPageFactory.php
@@ -49,7 +49,7 @@ class TypifiedPageFactory extends PageFactory
 	 */
 	public function createDecorator(ISearchContext $search_context)
 	{
-		$locator_factory = new DefaultElementLocatorFactory($search_context);
+		$locator_factory = new DefaultElementLocatorFactory($search_context, $this->seleniumSelector);
 
 		return new TypifiedPropertyDecorator($locator_factory, $this);
 	}

--- a/library/QATools/QATools/PageObject/Container.php
+++ b/library/QATools/QATools/PageObject/Container.php
@@ -78,7 +78,7 @@ class Container extends BaseContainer
 			return $page_url_matcher_registry;
 		};
 
-		$this['selenium_selector'] = function ($c) {
+		$this['selenium_selector'] = function () {
 			return new SeleniumSelector();
 		};
 	}

--- a/library/QATools/QATools/PageObject/Container.php
+++ b/library/QATools/QATools/PageObject/Container.php
@@ -77,6 +77,10 @@ class Container extends BaseContainer
 
 			return $page_url_matcher_registry;
 		};
+
+		$this['selenium_selector'] = function ($c) {
+			return new SeleniumSelector();
+		};
 	}
 
 }

--- a/library/QATools/QATools/PageObject/ElementLocator/DefaultElementLocator.php
+++ b/library/QATools/QATools/PageObject/ElementLocator/DefaultElementLocator.php
@@ -17,6 +17,7 @@ use QATools\QATools\PageObject\Exception\AnnotationException;
 use QATools\QATools\PageObject\Exception\ElementException;
 use QATools\QATools\PageObject\ISearchContext;
 use QATools\QATools\PageObject\Property;
+use QATools\QATools\PageObject\SeleniumSelector;
 
 /**
  * Class, that locates WebElements.
@@ -41,15 +42,27 @@ class DefaultElementLocator implements IElementLocator
 	protected $property;
 
 	/**
+	 * Selenium selector.
+	 *
+	 * @var SeleniumSelector
+	 */
+	protected $seleniumSelector;
+
+	/**
 	 * Creates a new element locator.
 	 *
-	 * @param Property       $property       Property.
-	 * @param ISearchContext $search_context The context to use when finding the element.
+	 * @param Property         $property          Property.
+	 * @param ISearchContext   $search_context    The context to use when finding the element.
+	 * @param SeleniumSelector $selenium_selector Selenium selector.
 	 */
-	public function __construct(Property $property, ISearchContext $search_context)
-	{
+	public function __construct(
+		Property $property,
+		ISearchContext $search_context,
+		SeleniumSelector $selenium_selector
+	) {
 		$this->property = $property;
 		$this->searchContext = $search_context;
+		$this->seleniumSelector = $selenium_selector;
 	}
 
 	/**
@@ -85,7 +98,11 @@ class DefaultElementLocator implements IElementLocator
 		$elements = array();
 
 		foreach ( $this->getSelectors() as $selector ) {
-			$elements = array_merge($elements, $this->searchContext->findAll('se', $selector));
+			$how = key($selector);
+			$using = $selector[$how];
+			$xpath = $this->seleniumSelector->translateToXPath($how, $using);
+
+			$elements = array_merge($elements, $this->searchContext->findAll('xpath', $xpath));
 		}
 
 		$element_count = count($elements);
@@ -164,7 +181,7 @@ class DefaultElementLocator implements IElementLocator
 		$selectors = $this->getSelectors();
 
 		foreach ( $selectors as $selector ) {
-			$exported_selectors[] = array('se' => $selector);
+			$exported_selectors[] = $selector;
 		}
 
 		return var_export($exported_selectors, true);

--- a/library/QATools/QATools/PageObject/ElementLocator/DefaultElementLocatorFactory.php
+++ b/library/QATools/QATools/PageObject/ElementLocator/DefaultElementLocatorFactory.php
@@ -13,6 +13,7 @@ namespace QATools\QATools\PageObject\ElementLocator;
 
 use QATools\QATools\PageObject\ISearchContext;
 use QATools\QATools\PageObject\Property;
+use QATools\QATools\PageObject\SeleniumSelector;
 
 /**
  * Factory, that creates locators for finding WebElements.
@@ -30,13 +31,22 @@ class DefaultElementLocatorFactory implements IElementLocatorFactory
 	protected $searchContext;
 
 	/**
+	 * Selenium selector.
+	 *
+	 * @var SeleniumSelector
+	 */
+	protected $seleniumSelector;
+
+	/**
 	 * Create locator factory instance.
 	 *
-	 * @param ISearchContext $search_context Search context.
+	 * @param ISearchContext   $search_context    Search context.
+	 * @param SeleniumSelector $selenium_selector Selenium selector.
 	 */
-	public function __construct(ISearchContext $search_context)
+	public function __construct(ISearchContext $search_context, SeleniumSelector $selenium_selector)
 	{
 		$this->searchContext = $search_context;
+		$this->seleniumSelector = $selenium_selector;
 	}
 
 	/**
@@ -48,7 +58,7 @@ class DefaultElementLocatorFactory implements IElementLocatorFactory
 	 */
 	public function createLocator(Property $property)
 	{
-		return new WaitingElementLocator($property, $this->searchContext);
+		return new WaitingElementLocator($property, $this->searchContext, $this->seleniumSelector);
 	}
 
 }

--- a/library/QATools/QATools/PageObject/ElementLocator/WaitingElementLocator.php
+++ b/library/QATools/QATools/PageObject/ElementLocator/WaitingElementLocator.php
@@ -15,6 +15,7 @@ use Behat\Mink\Element\NodeElement;
 use QATools\QATools\PageObject\Annotation\TimeoutAnnotation;
 use QATools\QATools\PageObject\ISearchContext;
 use QATools\QATools\PageObject\Property;
+use QATools\QATools\PageObject\SeleniumSelector;
 
 /**
  * Class, that locates WebElements that might not be present at the moment.
@@ -34,12 +35,16 @@ class WaitingElementLocator extends DefaultElementLocator
 	/**
 	 * Creates a new element locator.
 	 *
-	 * @param Property       $property       Property.
-	 * @param ISearchContext $search_context The context to use when finding the element.
+	 * @param Property         $property          Property.
+	 * @param ISearchContext   $search_context    The context to use when finding the element.
+	 * @param SeleniumSelector $selenium_selector Selenium selector.
 	 */
-	public function __construct(Property $property, ISearchContext $search_context)
-	{
-		parent::__construct($property, $search_context);
+	public function __construct(
+		Property $property,
+		ISearchContext $search_context,
+		SeleniumSelector $selenium_selector
+	) {
+		parent::__construct($property, $search_context, $selenium_selector);
 
 		/** @var TimeoutAnnotation[] $annotations */
 		$annotations = $property->getAnnotationsFromPropertyOrClass('@timeout');

--- a/library/QATools/QATools/PageObject/IPageFactory.php
+++ b/library/QATools/QATools/PageObject/IPageFactory.php
@@ -85,4 +85,14 @@ interface IPageFactory
 	 */
 	public function opened(Page $page);
 
+	/**
+	 * Translates provided how/using combo into XPath.
+	 *
+	 * @param string $how   How class constant.
+	 * @param string $using Using value.
+	 *
+	 * @return string
+	 */
+	public function translateToXPath($how, $using);
+
 }

--- a/library/QATools/QATools/PageObject/PageFactory.php
+++ b/library/QATools/QATools/PageObject/PageFactory.php
@@ -88,6 +88,13 @@ class PageFactory implements IPageFactory
 	protected $pageUrlMatcherRegistry;
 
 	/**
+	 * Selenium selector.
+	 *
+	 * @var SeleniumSelector
+	 */
+	protected $seleniumSelector;
+
+	/**
 	 * The current config.
 	 *
 	 * @var IConfig
@@ -126,6 +133,7 @@ class PageFactory implements IPageFactory
 		$this->urlNormalizer = $container_or_config['url_normalizer'];
 		$this->pageLocator = $container_or_config['page_locator'];
 		$this->pageUrlMatcherRegistry = $container_or_config['page_url_matcher_registry'];
+		$this->seleniumSelector = $container_or_config['selenium_selector'];
 	}
 
 	/**
@@ -324,6 +332,19 @@ class PageFactory implements IPageFactory
 		$resolved_page_class = $this->pageLocator->resolvePage($class_name);
 
 		return new $resolved_page_class($this);
+	}
+
+	/**
+	 * Translates provided how/using combo into XPath.
+	 *
+	 * @param string $how   How class constant.
+	 * @param string $using Using value.
+	 *
+	 * @return string
+	 */
+	public function translateToXPath($how, $using)
+	{
+		return $this->seleniumSelector->translateToXPath($how, $using);
 	}
 
 }

--- a/library/QATools/QATools/PageObject/PageFactory.php
+++ b/library/QATools/QATools/PageObject/PageFactory.php
@@ -125,7 +125,7 @@ class PageFactory implements IPageFactory
 			$container_or_config = $this->_createContainer();
 		}
 
-		$this->_setSession($session);
+		$this->_session = $session;
 		$this->config = $container_or_config['config'];
 
 		$this->_setAnnotationManager($container_or_config['annotation_manager']);
@@ -181,29 +181,9 @@ class PageFactory implements IPageFactory
 	 */
 	public function createDecorator(ISearchContext $search_context)
 	{
-		$locator_factory = new DefaultElementLocatorFactory($search_context);
+		$locator_factory = new DefaultElementLocatorFactory($search_context, $this->seleniumSelector);
 
 		return new DefaultPropertyDecorator($locator_factory, $this);
-	}
-
-	/**
-	 * Sets session.
-	 *
-	 * @param Session $session Session.
-	 *
-	 * @return self
-	 */
-	private function _setSession(Session $session)
-	{
-		$selectors_handler = $session->getSelectorsHandler();
-
-		if ( !$selectors_handler->isSelectorRegistered('se') ) {
-			$selectors_handler->registerSelector('se', new SeleniumSelector());
-		}
-
-		$this->_session = $session;
-
-		return $this;
 	}
 
 	/**

--- a/library/QATools/QATools/PageObject/SeleniumSelector.php
+++ b/library/QATools/QATools/PageObject/SeleniumSelector.php
@@ -12,7 +12,6 @@ namespace QATools\QATools\PageObject;
 
 
 use Behat\Mink\Selector\CssSelector;
-use Behat\Mink\Selector\SelectorInterface;
 use Behat\Mink\Selector\Xpath\Escaper;
 use QATools\QATools\PageObject\Exception\ElementException;
 
@@ -23,7 +22,7 @@ use QATools\QATools\PageObject\Exception\ElementException;
  *
  * @link http://bit.ly/qa-tools-findby-selector
  */
-class SeleniumSelector implements SelectorInterface
+class SeleniumSelector
 {
 
 	/**
@@ -50,74 +49,75 @@ class SeleniumSelector implements SelectorInterface
 	}
 
 	/**
-	 * Translates provided locator into XPath.
+	 * Translates provided how/using combo into XPath.
 	 *
-	 * @param mixed $locator Current selector locator.
+	 * @param string $how   How class constant.
+	 * @param string $using Using value.
 	 *
 	 * @return string
-	 * @throws ElementException When used selector is broken or not implemented.
+	 * @throws ElementException When given "$how" is not implemented.
+	 * @throws ElementException When given "$using" is empty.
 	 */
-	public function translateToXPath($locator)
+	public function translateToXPath($how, $using)
 	{
-		if ( !$locator || !is_array($locator) ) {
+		if ( empty($using) ) {
 			throw new ElementException(
-				'Incorrect Selenium selector format',
+				'The "using" part the Selenium selector is empty',
 				ElementException::TYPE_INCORRECT_SELECTOR
 			);
 		}
 
-		$selector = key($locator);
-		$locator = trim($locator[$selector]);
+		$using = trim($using);
 
-		if ( $selector == How::CLASS_NAME ) {
-			$locator = $this->_xpathEscaper->escapeLiteral(' ' . $locator . ' ');
+		if ( $how == How::CLASS_NAME ) {
+			$using = $this->_xpathEscaper->escapeLiteral(' ' . $using . ' ');
 
-			return "descendant-or-self::*[@class and contains(concat(' ', normalize-space(@class), ' '), " . $locator . ')]';
+			return "descendant-or-self::*[@class and contains(concat(' ', normalize-space(@class), ' '), " . $using . ')]';
 		}
-		elseif ( $selector == How::CSS ) {
-			return $this->_cssSelector->translateToXPath($locator);
+		elseif ( $how == How::CSS ) {
+			return $this->_cssSelector->translateToXPath($using);
 		}
-		elseif ( $selector == How::ID ) {
-			return 'descendant-or-self::*[@id = ' . $this->_xpathEscaper->escapeLiteral($locator) . ']';
+		elseif ( $how == How::ID ) {
+			return 'descendant-or-self::*[@id = ' . $this->_xpathEscaper->escapeLiteral($using) . ']';
 		}
-		elseif ( $selector == How::NAME ) {
-			return 'descendant-or-self::*[@name = ' . $this->_xpathEscaper->escapeLiteral($locator) . ']';
+		elseif ( $how == How::NAME ) {
+			return 'descendant-or-self::*[@name = ' . $this->_xpathEscaper->escapeLiteral($using) . ']';
 		}
-		elseif ( $selector == How::ID_OR_NAME ) {
-			$locator = $this->_xpathEscaper->escapeLiteral($locator);
+		elseif ( $how == How::ID_OR_NAME ) {
+			$using = $this->_xpathEscaper->escapeLiteral($using);
 
-			return 'descendant-or-self::*[@id = ' . $locator . ' or @name = ' . $locator . ']';
+			return 'descendant-or-self::*[@id = ' . $using . ' or @name = ' . $using . ']';
 		}
-		elseif ( $selector == How::TAG_NAME ) {
-			return 'descendant-or-self::' . $locator;
+		elseif ( $how == How::TAG_NAME ) {
+			return 'descendant-or-self::' . $using;
 		}
-		elseif ( $selector == How::LINK_TEXT ) {
-			$locator = $this->_xpathEscaper->escapeLiteral($locator);
+		elseif ( $how == How::LINK_TEXT ) {
+			$using = $this->_xpathEscaper->escapeLiteral($using);
 
-			return 'descendant-or-self::a[./@href][normalize-space(string(.)) = ' . $locator . ']';
+			return 'descendant-or-self::a[./@href][normalize-space(string(.)) = ' . $using . ']';
 		}
-		elseif ( $selector == How::LABEL ) {
-			$locator = $this->_xpathEscaper->escapeLiteral($locator);
+		elseif ( $how == How::LABEL ) {
+			$using = $this->_xpathEscaper->escapeLiteral($using);
 			$xpath_pieces = array();
-			$xpath_pieces[] = 'descendant-or-self::*[@id = (//label[normalize-space(string(.)) = ' . $locator . ']/@for)]';
-			$xpath_pieces[] = 'descendant-or-self::label[normalize-space(string(.)) = ' . $locator . ']//input';
+			$xpath_pieces[] = 'descendant-or-self::*[@id = (//label[normalize-space(string(.)) = ' . $using . ']/@for)]';
+			$xpath_pieces[] = 'descendant-or-self::label[normalize-space(string(.)) = ' . $using . ']//input';
 
 			return implode('|', $xpath_pieces);
 		}
-		elseif ( $selector == How::PARTIAL_LINK_TEXT ) {
-			$locator = $this->_xpathEscaper->escapeLiteral($locator);
+		elseif ( $how == How::PARTIAL_LINK_TEXT ) {
+			$using = $this->_xpathEscaper->escapeLiteral($using);
 
-			return 'descendant-or-self::a[./@href][contains(normalize-space(string(.)), ' . $locator . ')]';
+			return 'descendant-or-self::a[./@href][contains(normalize-space(string(.)), ' . $using . ')]';
 		}
-		elseif ( $selector == How::XPATH ) {
-			return $locator;
+		elseif ( $how == How::XPATH ) {
+			return $using;
 		}
 
 		/*case How::LINK_TEXT:
 		case How::PARTIAL_LINK_TEXT:*/
 
 		throw new ElementException(
-			sprintf('Selector type "%s" not yet implemented', $selector),
+			sprintf('The "%s" how is not yet implemented', $how),
 			ElementException::TYPE_UNKNOWN_SELECTOR
 		);
 	}

--- a/tests/QATools/QATools/BEM/Element/BlockTest.php
+++ b/tests/QATools/QATools/BEM/Element/BlockTest.php
@@ -161,7 +161,7 @@ class BlockTest extends PartTestCase
 		$this->_prepareSearchFixture();
 
 		$block = $this->createPart();
-		$node = $block->find('se', $this->_locator);
+		$node = $block->find('xpath', $this->getLocatorXPath());
 
 		$this->assertEquals('sub-xpath-1', $node->getXpath());
 	}
@@ -171,7 +171,7 @@ class BlockTest extends PartTestCase
 		$this->_prepareSearchFixture(true);
 
 		$block = $this->createPart();
-		$node = $block->find('se', $this->_locator);
+		$node = $block->find('xpath', $this->getLocatorXPath());
 
 		$this->assertNull($node);
 	}
@@ -181,7 +181,7 @@ class BlockTest extends PartTestCase
 		$this->_prepareSearchFixture();
 
 		$block = $this->createPart();
-		$nodes = $block->findAll('se', $this->_locator);
+		$nodes = $block->findAll('xpath', $this->getLocatorXPath());
 
 		$this->assertCount(2, $nodes);
 		$this->assertEquals('sub-xpath-1', $nodes[0]->getXpath());
@@ -193,9 +193,22 @@ class BlockTest extends PartTestCase
 		$this->_prepareSearchFixture(true);
 
 		$block = $this->createPart();
-		$nodes = $block->findAll('se', $this->_locator);
+		$nodes = $block->findAll('xpath', $this->getLocatorXPath());
 
 		$this->assertCount(0, $nodes);
+	}
+
+	/**
+	 * Returns xpath matching predefined locator.
+	 *
+	 * @return string
+	 */
+	protected function getLocatorXPath()
+	{
+		$how = key($this->_locator);
+		$using = $this->_locator[$how];
+
+		return $this->pageFactory->translateToXPath($how, $using);
 	}
 
 	/**
@@ -207,7 +220,9 @@ class BlockTest extends PartTestCase
 	 */
 	private function _prepareSearchFixture($empty_result = false)
 	{
-		$locator = array('className' => 'block-name__element-name');
+		$how = 'className';
+		$using = 'block-name__element-name';
+		$locator = array($how => $using);
 
 		$result1 = $result2 = array();
 
@@ -216,22 +231,27 @@ class BlockTest extends PartTestCase
 			$result2[] = $this->createNodeElement('sub-xpath-2');
 		}
 
+		$this->pageFactory->shouldReceive('translateToXPath')
+			->with($how, $using)
+			->once()
+			->andReturn('BEM_XPATH_TRANSLATED');
+
 		if ( $this->elementFinder !== null ) {
 			// Since Mink v1.11.0.
 			$this->elementFinder
 				->shouldReceive('findAll')
-				->with('se', $locator, $this->_nodes[0]->getXpath())
+				->with('xpath', 'BEM_XPATH_TRANSLATED', $this->_nodes[0]->getXpath())
 				->andReturn($result1);
 			$this->elementFinder
 				->shouldReceive('findAll')
-				->with('se', $locator, $this->_nodes[1]->getXpath())
+				->with('xpath', 'BEM_XPATH_TRANSLATED', $this->_nodes[1]->getXpath())
 				->andReturn($result2);
 		}
 		else {
 			// Older Mink version.
 			$this->selectorsHandler
 				->shouldReceive('selectorToXpath')
-				->with('se', $locator)
+				->with('xpath', 'BEM_XPATH_TRANSLATED')
 				->andReturn('BEM_XPATH');
 
 			$this->driver

--- a/tests/QATools/QATools/BEM/ElementLocator/BEMElementLocatorFactoryTest.php
+++ b/tests/QATools/QATools/BEM/ElementLocator/BEMElementLocatorFactoryTest.php
@@ -15,6 +15,7 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use QATools\QATools\BEM\ElementLocator\BEMElementLocatorFactory;
 use Mockery as m;
+use QATools\QATools\PageObject\SeleniumSelector;
 
 class BEMElementLocatorFactoryTest extends TestCase
 {
@@ -33,8 +34,9 @@ class BEMElementLocatorFactoryTest extends TestCase
 	public function testCreateLocator()
 	{
 		$search_context = m::mock('\\QATools\\QATools\\PageObject\\ISearchContext');
+		$selenium_selector = m::mock(SeleniumSelector::class);
 		$locator_helper = m::mock('\\QATools\\QATools\\BEM\\ElementLocator\\LocatorHelper');
-		$factory = new BEMElementLocatorFactory($search_context, $locator_helper);
+		$factory = new BEMElementLocatorFactory($search_context, $selenium_selector, $locator_helper);
 
 		$property = m::mock(self::PROPERTY_CLASS);
 		$locator = $factory->createLocator($property);

--- a/tests/QATools/QATools/HtmlElements/Element/SelectTest.php
+++ b/tests/QATools/QATools/HtmlElements/Element/SelectTest.php
@@ -70,9 +70,17 @@ class SelectTest extends AbstractTypifiedElementTest
 	{
 		$this->expectDriverGetTagName('option');
 
-		$this->webElement->shouldReceive('findAll')->with('se', array('tagName' => 'option'))->once()->andReturn(
-			array($this->createNodeElement())
-		);
+		$this->pageFactory->shouldReceive('translateToXPath')
+			->with('tagName', 'option')
+			->once()
+			->andReturn('OK');
+
+		$this->webElement->shouldReceive('findAll')
+			->with('xpath', 'OK')
+			->once()
+			->andReturn(
+				array($this->createNodeElement())
+			);
 
 		$this->typifiedElement = $this->createElement();
 

--- a/tests/QATools/QATools/Live/HtmlElements/Element/FormTest.php
+++ b/tests/QATools/QATools/Live/HtmlElements/Element/FormTest.php
@@ -37,7 +37,7 @@ class FormTest extends TypifiedElementTestCase
 		$page->findById('generate-btn')->click();
 
 		/** @var Form $form */
-		$form = $this->createElement(array('id' => 'test-form'));
+		$form = $this->createElement('id', 'test-form');
 		$delayed_element = $form->waitFor(2, function (Form $given_form) {
 			return $given_form->find('css', '#delayed-element');
 		});

--- a/tests/QATools/QATools/Live/HtmlElements/Element/LabeledElementTest.php
+++ b/tests/QATools/QATools/Live/HtmlElements/Element/LabeledElementTest.php
@@ -32,7 +32,7 @@ class LabeledElementTest extends TypifiedElementTestCase
 	public function testGetLabel($id, $label_text)
 	{
 		/** @var LabeledElement $label_element */
-		$label_element = $this->createElement(array('id' => $id));
+		$label_element = $this->createElement('id', $id);
 		$label = $label_element->getLabel();
 
 		if ( is_null($label_text) ) {
@@ -50,7 +50,7 @@ class LabeledElementTest extends TypifiedElementTestCase
 	public function testGetLabelText($id, $label_text)
 	{
 		/** @var LabeledElement $label_element */
-		$label_element = $this->createElement(array('id' => $id));
+		$label_element = $this->createElement('id', $id);
 		$this->assertSame($label_text, $label_element->getLabelText());
 	}
 
@@ -60,7 +60,7 @@ class LabeledElementTest extends TypifiedElementTestCase
 	public function testGetText($id, $label_text)
 	{
 		/** @var LabeledElement $label_element */
-		$label_element = $this->createElement(array('id' => $id));
+		$label_element = $this->createElement('id', $id);
 		$this->assertSame($label_text, $label_element->getText());
 	}
 

--- a/tests/QATools/QATools/Live/HtmlElements/Element/RadioGroupTest.php
+++ b/tests/QATools/QATools/Live/HtmlElements/Element/RadioGroupTest.php
@@ -33,7 +33,7 @@ class RadioGroupTest extends TypifiedElementTestCase
 	public function testGetButtonsWithName()
 	{
 		/** @var RadioGroup $radio_group */
-		$radio_group = $this->createElement(array('xpath' => self::XPATH_RADIO_GROUP));
+		$radio_group = $this->createElement('xpath', self::XPATH_RADIO_GROUP);
 
 		$this->assertCount(4, $radio_group);
 		$this->assertInstanceOf(self::RADIO_CLASS, $radio_group[0]);
@@ -42,9 +42,7 @@ class RadioGroupTest extends TypifiedElementTestCase
 	public function testGetButtonsWithoutName()
 	{
 		/** @var RadioGroup $radio_group */
-		$radio_group = $this->createElement(array(
-			'xpath' => "/descendant-or-self::*[@type = 'radio']",
-		));
+		$radio_group = $this->createElement('xpath', "/descendant-or-self::*[@type = 'radio']");
 
 		$this->assertCount(5, $radio_group);
 		$this->assertInstanceOf(self::RADIO_CLASS, $radio_group[0]);
@@ -53,7 +51,7 @@ class RadioGroupTest extends TypifiedElementTestCase
 	public function testSelection()
 	{
 		/** @var RadioGroup $radio_group */
-		$radio_group = $this->createElement(array('xpath' => self::XPATH_RADIO_GROUP));
+		$radio_group = $this->createElement('xpath', self::XPATH_RADIO_GROUP);
 
 		$this->assertFalse($radio_group->hasSelectedButton(), 'No radio button is selected initially');
 		$radio_group->selectButtonByValue(4);
@@ -63,7 +61,7 @@ class RadioGroupTest extends TypifiedElementTestCase
 	public function testAccessOfSingleRadioButton()
 	{
 		/** @var RadioGroup $radio_group */
-		$radio_group = $this->createElement(array('xpath' => self::XPATH_RADIO_GROUP));
+		$radio_group = $this->createElement('xpath', self::XPATH_RADIO_GROUP);
 
 		$this->assertFalse($radio_group->hasSelectedButton(), 'No radio button is selected initially');
 		$radio_group[2]->select();
@@ -73,7 +71,7 @@ class RadioGroupTest extends TypifiedElementTestCase
 	public function testIteratingRadioButtons()
 	{
 		/** @var RadioGroup $radio_group */
-		$radio_group = $this->createElement(array('xpath' => self::XPATH_RADIO_GROUP));
+		$radio_group = $this->createElement('xpath', self::XPATH_RADIO_GROUP);
 
 		$this->assertFalse($radio_group->hasSelectedButton(), 'No radio button is selected initially');
 		$this->assertCount(4, $radio_group);
@@ -90,13 +88,15 @@ class RadioGroupTest extends TypifiedElementTestCase
 	/**
 	 * Creates element.
 	 *
-	 * @param array $selector Selector.
+	 * @param string $how   How class constant.
+	 * @param string $using Using value.
 	 *
 	 * @return RadioGroup
 	 */
-	protected function createElement(array $selector)
+	protected function createElement($how, $using)
 	{
-		$node_elements = $this->session->getPage()->findAll('se', $selector);
+		$xpath = $this->pageFactory->translateToXPath($how, $using);
+		$node_elements = $this->session->getPage()->findAll('xpath', $xpath);
 
 		return call_user_func($this->elementClass . '::fromNodeElements', $node_elements, null, $this->pageFactory);
 	}

--- a/tests/QATools/QATools/Live/HtmlElements/Element/SelectTest.php
+++ b/tests/QATools/QATools/Live/HtmlElements/Element/SelectTest.php
@@ -31,7 +31,7 @@ class SelectTest extends TypifiedElementTestCase
 	public function testGetOptions()
 	{
 		/** @var Select $element */
-		$element = $this->createElement(array('id' => 'select-complex'));
+		$element = $this->createElement('id', 'select-complex');
 		$options = $element->getOptions();
 
 		$this->assertCount(3, $options);
@@ -42,7 +42,7 @@ class SelectTest extends TypifiedElementTestCase
 	public function testGetOptionsByValue()
 	{
 		/** @var Select $element */
-		$element = $this->createElement(array('id' => 'select-complex'));
+		$element = $this->createElement('id', 'select-complex');
 		$options = $element->getOptionsByValue('v1');
 
 		$this->assertCount(1, $options);
@@ -53,7 +53,7 @@ class SelectTest extends TypifiedElementTestCase
 	public function testGetOptionsByText()
 	{
 		/** @var Select $element */
-		$element = $this->createElement(array('id' => 'select-complex'));
+		$element = $this->createElement('id', 'select-complex');
 		$options = $element->getOptionsByText('t1');
 
 		$this->assertCount(1, $options);
@@ -64,7 +64,7 @@ class SelectTest extends TypifiedElementTestCase
 	public function testSelectByText()
 	{
 		/** @var Select $element */
-		$element = $this->createElement(array('id' => 'select-complex'));
+		$element = $this->createElement('id', 'select-complex');
 		$element->selectByText('t1');
 
 		$options = $element->getSelectedOptions();

--- a/tests/QATools/QATools/Live/HtmlElements/Element/TextInputTest.php
+++ b/tests/QATools/QATools/Live/HtmlElements/Element/TextInputTest.php
@@ -32,7 +32,7 @@ class TextInputTest extends TypifiedElementTestCase
 	public function testSendKeys($element_id, $expected_text)
 	{
 		/** @var TextInput $element */
-		$element = $this->createElement(array('id' => $element_id));
+		$element = $this->createElement('id', $element_id);
 
 		$this->assertEmpty($element->getText());
 		$this->assertSame($element, $element->sendKeys($expected_text));

--- a/tests/QATools/QATools/Live/HtmlElements/Element/TypifiedElementTestCase.php
+++ b/tests/QATools/QATools/Live/HtmlElements/Element/TypifiedElementTestCase.php
@@ -13,11 +13,9 @@ namespace tests\QATools\QATools\Live\HtmlElements\Element;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Mink;
-use Behat\Mink\Selector\SelectorsHandler;
 use Behat\Mink\Session;
 use QATools\QATools\HtmlElements\Element\AbstractTypifiedElement;
 use QATools\QATools\PageObject\Element\WebElement;
-use QATools\QATools\PageObject\SeleniumSelector;
 use tests\QATools\QATools\Live\AbstractLiveTestCase;
 
 class TypifiedElementTestCase extends AbstractLiveTestCase
@@ -56,14 +54,14 @@ class TypifiedElementTestCase extends AbstractLiveTestCase
 	/**
 	 * Creates element.
 	 *
-	 * @param array $selector Selector.
+	 * @param string $how   How class constant.
+	 * @param string $using Using value.
 	 *
 	 * @return AbstractTypifiedElement
 	 */
-	protected function createElement(array $selector)
+	protected function createElement($how, $using)
 	{
-		$selenium_selector = new SeleniumSelector();
-		$xpath = $selenium_selector->translateToXPath($selector);
+		$xpath = $this->pageFactory->translateToXPath($how, $using);
 
 		$web_element = new WebElement(new NodeElement($xpath, $this->session), $this->pageFactory);
 

--- a/tests/QATools/QATools/PageObject/ContainerTest.php
+++ b/tests/QATools/QATools/PageObject/ContainerTest.php
@@ -18,6 +18,7 @@ use QATools\QATools\PageObject\Annotation\PageUrlAnnotation;
 use QATools\QATools\PageObject\Config\Config;
 use QATools\QATools\PageObject\Container;
 use QATools\QATools\PageObject\PageLocator\DefaultPageLocator;
+use QATools\QATools\PageObject\SeleniumSelector;
 use QATools\QATools\PageObject\Url\Normalizer;
 
 class ContainerTest extends TestCase
@@ -102,6 +103,14 @@ class ContainerTest extends TestCase
 		$this->assertInstanceOf(
 			'\\QATools\\QATools\\PageObject\\PageUrlMatcher\\PageUrlMatcherRegistry',
 			$this->container['page_url_matcher_registry']
+		);
+	}
+
+	public function testSeleniumSelector()
+	{
+		$this->assertInstanceOf(
+			SeleniumSelector::class,
+			$this->container['selenium_selector']
 		);
 	}
 

--- a/tests/QATools/QATools/PageObject/ElementLocator/DefaultElementLocatorFactoryTest.php
+++ b/tests/QATools/QATools/PageObject/ElementLocator/DefaultElementLocatorFactoryTest.php
@@ -15,6 +15,7 @@ use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use QATools\QATools\PageObject\ElementLocator\DefaultElementLocatorFactory;
+use QATools\QATools\PageObject\SeleniumSelector;
 
 class DefaultElementLocatorFactoryTest extends TestCase
 {
@@ -32,8 +33,9 @@ class DefaultElementLocatorFactoryTest extends TestCase
 
 	public function testCreateLocator()
 	{
+		$selenium_selector = m::mock(SeleniumSelector::class);
 		$search_context = m::mock('\\QATools\\QATools\\PageObject\\ISearchContext');
-		$factory = new DefaultElementLocatorFactory($search_context);
+		$factory = new DefaultElementLocatorFactory($search_context, $selenium_selector);
 
 		$property = m::mock(self::PROPERTY_CLASS);
 		$property->shouldReceive('getAnnotationsFromPropertyOrClass')->with('@timeout')->once()->andReturn(array());

--- a/tests/QATools/QATools/PageObject/ElementLocator/WaitingElementLocatorTest.php
+++ b/tests/QATools/QATools/PageObject/ElementLocator/WaitingElementLocatorTest.php
@@ -44,7 +44,15 @@ class WaitingElementLocatorTest extends DefaultElementLocatorTest
 		$this->property->shouldReceive('isDataTypeCollection')->andReturn($is_collection);
 
 		foreach ( $selectors as $selector ) {
-			$this->searchContext->shouldReceive('findAll')->with('se', $selector)->andReturn(array($node_element));
+			$how = key($selector);
+			$using = $selector[$how];
+
+			$this->expectXPathTranslation($how, $using);
+
+			$this->searchContext->shouldReceive('findAll')
+				->with('xpath', '{{' . $using . '}}')
+				->once()
+				->andReturn(array($node_element));
 		}
 
 		$this->searchContext

--- a/tests/QATools/QATools/PageObject/PageFactoryTest.php
+++ b/tests/QATools/QATools/PageObject/PageFactoryTest.php
@@ -100,9 +100,6 @@ class PageFactoryTest extends TestCase
 		$this->pageFactory->shouldReceive('initElementContainer')->andReturn(\Mockery::self());
 		$this->pageFactory->shouldReceive('initElements')->andReturn(\Mockery::self());
 
-		$this->selectorsHandler->shouldReceive('isSelectorRegistered')->andReturn(false);
-		$this->selectorsHandler->shouldReceive('registerSelector')->with('se', m::any());
-
 		$this->annotationManager = m::mock(self::ANNOTATION_MANAGER_CLASS);
 		$this->seleniumSelector = m::mock(SeleniumSelector::class);
 		$config = new Config(array('base_url' => 'http://domain.tld'));

--- a/tests/QATools/QATools/PageObject/PropertyDecorator/DefaultPropertyDecoratorTest.php
+++ b/tests/QATools/QATools/PageObject/PropertyDecorator/DefaultPropertyDecoratorTest.php
@@ -24,6 +24,7 @@ use QATools\QATools\PageObject\Proxy\WebElementProxy;
 use mindplay\annotations\AnnotationCache;
 use mindplay\annotations\AnnotationManager;
 use Mockery as m;
+use QATools\QATools\PageObject\SeleniumSelector;
 use tests\QATools\QATools\TestCase;
 
 class DefaultPropertyDecoratorTest extends TestCase
@@ -185,27 +186,6 @@ class DefaultPropertyDecoratorTest extends TestCase
 	}
 
 	/**
-	 * Creates NodeElement mock.
-	 *
-	 * @param string|null $xpath XPath of the element.
-	 *
-	 * @return NodeElement
-	 */
-	protected function createNodeElement($xpath = null)
-	{
-		$element = parent::createNodeElement($xpath);
-
-		if ( $this->getName(false) === 'testProxyWebElement' ) {
-			$this->selectorsHandler
-				->shouldReceive('selectorToXpath')
-				->with('se', array('xpath' => $xpath))
-				->andReturn($xpath);
-		}
-
-		return $element;
-	}
-
-	/**
 	 * Verifies, that proxy did that's needed.
 	 *
 	 * @param IProxy $proxy         Proxy object.
@@ -238,12 +218,15 @@ class DefaultPropertyDecoratorTest extends TestCase
 	{
 		/** @var $search_context ISearchContext */
 		$search_context = m::mock('\\QATools\\QATools\\PageObject\\ISearchContext');
+
+		$selenium_selector = m::mock(SeleniumSelector::class);
+
 		$annotation_manager = new AnnotationManager();
 		$annotation_manager->cache = new AnnotationCache(sys_get_temp_dir());
 
 		/** @var $page_factory IPageFactory */
 		$page_factory = m::mock('\\QATools\\QATools\\PageObject\\IPageFactory');
-		$locator_factory = new DefaultElementLocatorFactory($search_context);
+		$locator_factory = new DefaultElementLocatorFactory($search_context, $selenium_selector);
 
 		/** @var $decorator IPropertyDecorator */
 		$decorator = new $this->decoratorClass($locator_factory, $page_factory);

--- a/tests/QATools/QATools/PageObject/Proxy/AbstractProxyTestCase.php
+++ b/tests/QATools/QATools/PageObject/Proxy/AbstractProxyTestCase.php
@@ -98,13 +98,6 @@ abstract class AbstractProxyTestCase extends AbstractElementCollectionTestCase
 			$this->createNodeElement('XPATH2'),
 		);
 
-		foreach ( $node_elements as $node_element ) {
-			$this->selectorsHandler
-				->shouldReceive('selectorToXpath')
-				->with('se', array('xpath' => $node_element->getXpath()))
-				->andReturn($node_element->getXpath());
-		}
-
 		$this->locator->shouldReceive('findAll')->once()->andReturn($node_elements);
 
 		return $node_elements;

--- a/tests/QATools/QATools/PageObject/SeleniumSelectorTest.php
+++ b/tests/QATools/QATools/PageObject/SeleniumSelectorTest.php
@@ -38,25 +38,13 @@ class SeleniumSelectorTest extends TestCase
 		$this->selector = new SeleniumSelector();
 	}
 
-	/**
-	 * @dataProvider notImplementedDataProvider
-	 */
-	public function testNotImplemented(array $locator)
+	public function testNotImplemented()
 	{
 		$this->expectException('QATools\\QATools\\PageObject\\Exception\\ElementException');
-		$this->expectExceptionMessage('Selector type "' . key($locator) . '" not yet implemented');
+		$this->expectExceptionMessage('The "not-implemented-selector" how is not yet implemented');
 		$this->expectExceptionCode(ElementException::TYPE_UNKNOWN_SELECTOR);
 
-		$this->selector->translateToXPath($locator);
-	}
-
-	public function notImplementedDataProvider()
-	{
-		return array(
-			array(
-				array('not-implemented-selector' => ''),
-			),
-		);
+		$this->selector->translateToXPath('not-implemented-selector', 'not empty');
 	}
 
 	/**
@@ -64,7 +52,7 @@ class SeleniumSelectorTest extends TestCase
 	 *
 	 * @dataProvider correctDataProvider
 	 */
-	public function testCorrect(array $locator, $expected_count)
+	public function testCorrect($how, $using, $expected_count)
 	{
 		$dom = new \DOMDocument('1.0', 'UTF-8');
 
@@ -75,7 +63,7 @@ class SeleniumSelectorTest extends TestCase
 			$dom->loadHTMLFile(__DIR__ . '/Fixture/selector_test.html');
 		}
 
-		$xpath = $this->selector->translateToXPath($locator);
+		$xpath = $this->selector->translateToXPath($how, $using);
 
 		$dom_xpath = new \DOMXPath($dom);
 		$node_list = $dom_xpath->query($xpath);
@@ -92,90 +80,72 @@ class SeleniumSelectorTest extends TestCase
 	{
 		return array(
 			How::CLASS_NAME . ' (partial)' => array(
-				array(How::CLASS_NAME => 'class-one'), 2,
+				How::CLASS_NAME, 'class-one', 2,
 			),
 			How::CLASS_NAME . ' (exact)' => array(
-				array(How::CLASS_NAME => 'class-two'), 1,
+				How::CLASS_NAME, 'class-two', 1,
 			),
 			How::CSS . ' (tag name)' => array(
-				array(How::CSS => 'p'), 2,
+				How::CSS, 'p', 2,
 			),
 			How::CSS . ' (id)' => array(
-				array(How::CSS => '#the-paragraph'), 1,
+				How::CSS, '#the-paragraph', 1,
 			),
 			How::CSS . ' (class name)' => array(
-				array(How::CSS => '.class-one'), 2,
+				How::CSS, '.class-one', 2,
 			),
 			How::CSS . ' (mix)' => array(
-				array(How::CSS => '.class-one.class-two'), 1,
+				How::CSS, '.class-one.class-two', 1,
 			),
 			How::ID => array(
-				array(How::ID => 'the-paragraph'), 1,
+				How::ID, 'the-paragraph', 1,
 			),
 			How::NAME => array(
-				array(How::NAME => 'field'), 3,
+				How::NAME, 'field', 3,
 			),
 			How::ID_OR_NAME => array(
-				array(How::ID_OR_NAME => 'field'), 4,
+				How::ID_OR_NAME, 'field', 4,
 			),
 			How::LINK_TEXT => array(
-				array(How::LINK_TEXT => 'cheese'), 1,
+				How::LINK_TEXT, 'cheese', 1,
 			),
 			How::PARTIAL_LINK_TEXT => array(
-				array(How::PARTIAL_LINK_TEXT => 'cheese'), 2,
+				How::PARTIAL_LINK_TEXT, 'cheese', 2,
 			),
 			How::TAG_NAME => array(
-				array(How::TAG_NAME => 'a'), 3,
+				How::TAG_NAME, 'a', 3,
 			),
 			How::XPATH => array(
-				array(How::XPATH => 'descendant-or-self::a[@name]'), 1,
+				How::XPATH, 'descendant-or-self::a[@name]', 1,
 			),
 			How::LABEL . ' (incomplete label)' => array(
-				array(How::LABEL => 'label'), 0,
+				How::LABEL, 'label', 0,
 			),
 			How::LABEL . ' (preceding-label)' => array(
-				array(How::LABEL => 'label text 2'), 1,
+				How::LABEL, 'label text 2', 1,
 			),
 			How::LABEL . ' (following-label)' => array(
-				array(How::LABEL => 'label text 3'), 1,
+				How::LABEL, 'label text 3', 1,
 			),
 			How::LABEL . ' (label-input-inside)' => array(
-				array(How::LABEL => 'label text 4'), 1,
+				How::LABEL, 'label text 4', 1,
 			),
 			How::LABEL . ' (label-textarea)' => array(
-				array(How::LABEL => 'label textarea'), 1,
+				How::LABEL, 'label textarea', 1,
 			),
 			How::LABEL . ' (label-select)' => array(
-				array(How::LABEL => 'label select'), 1,
+				How::LABEL, 'label select', 1,
 			),
 		);
 	}
 
-	/**
-	 * Testing incorrect locators.
-	 *
-	 * @dataProvider incorrectDataProvider
-	 */
-	public function testIncorrect($locator)
+	public function testIncorrect()
 	{
 		$this->expectException('\QATools\QATools\PageObject\Exception\ElementException');
 		$this->expectExceptionCode(\QATools\QATools\PageObject\Exception\ElementException::TYPE_INCORRECT_SELECTOR);
-		$this->expectExceptionMessage('Incorrect Selenium selector format');
+		$this->expectExceptionMessage('The "using" part the Selenium selector is empty');
 
-		$this->selector->translateToXPath($locator);
-	}
-
-	/**
-	 * Returns locators, in incorrect format.
-	 *
-	 * @return array
-	 */
-	public function incorrectDataProvider()
-	{
-		return array(
-			array(''),
-			array('//html'),
-		);
+		$this->selector->translateToXPath(How::ID, '');
 	}
 
 }

--- a/tests/QATools/QATools/TestCase.php
+++ b/tests/QATools/QATools/TestCase.php
@@ -65,8 +65,6 @@ class TestCase extends \PHPUnit\Framework\TestCase
 	protected function setUpTest()
 	{
 		$handler = m::mock('\\Behat\\Mink\\Selector\\SelectorsHandler');
-		$handler->shouldReceive('selectorToXpath')->with('se', array('xpath' => 'XPATH'))->andReturn('XPATH');
-		$handler->shouldReceive('selectorToXpath')->with('se', array('xpath' => 'XPATH_ROOT'))->andReturn('/XPATH');
 		$this->selectorsHandler = $handler;
 
 		$this->session = m::mock('\\Behat\\Mink\\Session');


### PR DESCRIPTION
This library injects the `se` selector handler into Mink Session to ease Selenium selector resolution from the `@find-by` annotations. This worked until the Mink deprecated such an approach.

This PR adds the `PageFactory::translateToXPath` method, which transforms the how/using selectors (e.g. `array('css' => 'body')` used in the `@find-by` annotations into an XPath, that other Mink methods can understand without additional help.

Internally the `PageFactory::translateToXPath` method is called only during annotation handling. The method itself should be used before any `find` or `findAll` call when working with the Selenium selector.

Also if somebody figured out about the `se` selector handler, then it won't work anymore and the above-mentioned method needs to be used instead.

Closes #104.