### PR TITLE
Use "static" instead of "self" in DocBlocks

### DIFF
--- a/library/QATools/QATools/HtmlElements/Element/AbstractTypifiedElement.php
+++ b/library/QATools/QATools/HtmlElements/Element/AbstractTypifiedElement.php
@@ -186,7 +186,7 @@ abstract class AbstractTypifiedElement implements ITypifiedElement, INodeElement
 	 *
 	 * @param string $name Name to set.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function setName($name)
 	{

--- a/library/QATools/QATools/HtmlElements/Element/AbstractTypifiedElementCollection.php
+++ b/library/QATools/QATools/HtmlElements/Element/AbstractTypifiedElementCollection.php
@@ -49,7 +49,7 @@ abstract class AbstractTypifiedElementCollection extends AbstractElementCollecti
 	 *
 	 * @param string $name Name to set.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function setName($name)
 	{

--- a/library/QATools/QATools/HtmlElements/Element/Button.php
+++ b/library/QATools/QATools/HtmlElements/Element/Button.php
@@ -31,7 +31,7 @@ class Button extends AbstractTypifiedElement
 	/**
 	 * Clicks the button.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function click()
 	{

--- a/library/QATools/QATools/HtmlElements/Element/Checkbox.php
+++ b/library/QATools/QATools/HtmlElements/Element/Checkbox.php
@@ -29,7 +29,7 @@ class Checkbox extends LabeledElement implements ISimpleSetter
 	/**
 	 * Checks checkbox if it is not already checked.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function check()
 	{
@@ -41,7 +41,7 @@ class Checkbox extends LabeledElement implements ISimpleSetter
 	/**
 	 * Unchecks checkbox if it is not already unchecked.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function uncheck()
 	{
@@ -55,7 +55,7 @@ class Checkbox extends LabeledElement implements ISimpleSetter
 	 *
 	 * @param boolean|null $check_or_uncheck Tells, how checkbox state should be altered.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function toggle($check_or_uncheck = null)
 	{
@@ -81,7 +81,7 @@ class Checkbox extends LabeledElement implements ISimpleSetter
 	 *
 	 * @param mixed $value New value.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function setValue($value)
 	{

--- a/library/QATools/QATools/HtmlElements/Element/FileInput.php
+++ b/library/QATools/QATools/HtmlElements/Element/FileInput.php
@@ -43,7 +43,7 @@ class FileInput extends AbstractTypifiedElement implements ISimpleSetter
 	 *
 	 * @param string $filename Filename.
 	 *
-	 * @return self
+	 * @return static
 	 * @throws FileInputException When file could not be found on disk.
 	 */
 	public function setFileToUpload($filename)
@@ -65,7 +65,7 @@ class FileInput extends AbstractTypifiedElement implements ISimpleSetter
 	 *
 	 * @param mixed $value New value.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function setValue($value)
 	{

--- a/library/QATools/QATools/HtmlElements/Element/Form.php
+++ b/library/QATools/QATools/HtmlElements/Element/Form.php
@@ -36,7 +36,7 @@ class Form extends AbstractElementContainer
 	 *
 	 * @param array $form_data Associative array with keys matching field names.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function fill(array $form_data)
 	{
@@ -127,7 +127,7 @@ class Form extends AbstractElementContainer
 	 * @param ITypifiedElement $typified_element Element, to set a value for.
 	 * @param mixed            $value            Element value to set.
 	 *
-	 * @return self
+	 * @return static
 	 * @throws FormException When element doesn't support value changing.
 	 */
 	public function setValue(ITypifiedElement $typified_element, $value)
@@ -147,7 +147,7 @@ class Form extends AbstractElementContainer
 	/**
 	 * Submits a form.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function submit()
 	{

--- a/library/QATools/QATools/HtmlElements/Element/ISimpleSetter.php
+++ b/library/QATools/QATools/HtmlElements/Element/ISimpleSetter.php
@@ -24,7 +24,7 @@ interface ISimpleSetter
 	 *
 	 * @param mixed $value New value.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function setValue($value);
 

--- a/library/QATools/QATools/HtmlElements/Element/ITypifiedElement.php
+++ b/library/QATools/QATools/HtmlElements/Element/ITypifiedElement.php
@@ -26,7 +26,7 @@ interface ITypifiedElement extends INamed
 	 *
 	 * @param string $name Name to set.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function setName($name);
 

--- a/library/QATools/QATools/HtmlElements/Element/Link.php
+++ b/library/QATools/QATools/HtmlElements/Element/Link.php
@@ -30,7 +30,7 @@ class Link extends AbstractTypifiedElement
 	/**
 	 * Click the link.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function click()
 	{

--- a/library/QATools/QATools/HtmlElements/Element/RadioButton.php
+++ b/library/QATools/QATools/HtmlElements/Element/RadioButton.php
@@ -29,7 +29,7 @@ class RadioButton extends LabeledElement
 	/**
 	 * Selects radio button uf it's not already selected.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function select()
 	{

--- a/library/QATools/QATools/HtmlElements/Element/RadioGroup.php
+++ b/library/QATools/QATools/HtmlElements/Element/RadioGroup.php
@@ -85,7 +85,7 @@ class RadioGroup extends AbstractTypifiedElementCollection implements ISimpleSet
 	 *
 	 * @param string $text Text.
 	 *
-	 * @return self
+	 * @return static
 	 * @throws RadioGroupException When radio button with given label text wasn't found.
 	 */
 	public function selectButtonByLabelText($text)
@@ -110,7 +110,7 @@ class RadioGroup extends AbstractTypifiedElementCollection implements ISimpleSet
 	 *
 	 * @param string $value The value to match against.
 	 *
-	 * @return self
+	 * @return static
 	 * @throws RadioGroupException When radio button with given value wasn't found.
 	 */
 	public function selectButtonByValue($value)
@@ -135,7 +135,7 @@ class RadioGroup extends AbstractTypifiedElementCollection implements ISimpleSet
 	 *
 	 * @param integer $index Index of a radio button to be selected.
 	 *
-	 * @return self
+	 * @return static
 	 * @throws RadioGroupException When non-existing index was given.
 	 */
 	public function selectButtonByIndex($index)
@@ -159,7 +159,7 @@ class RadioGroup extends AbstractTypifiedElementCollection implements ISimpleSet
 	 *
 	 * @param mixed $value New value.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function setValue($value)
 	{

--- a/library/QATools/QATools/HtmlElements/Element/Select.php
+++ b/library/QATools/QATools/HtmlElements/Element/Select.php
@@ -132,7 +132,7 @@ class Select extends AbstractTypifiedElement implements ISimpleSetter
 	 * @param string  $text        The visible text to match against.
 	 * @param boolean $exact_match Search for exact text.
 	 *
-	 * @return self
+	 * @return static
 	 * @throws SelectException No options were found by given text.
 	 */
 	public function selectByText($text, $exact_match = true)
@@ -152,7 +152,7 @@ class Select extends AbstractTypifiedElement implements ISimpleSetter
 	 * @param string  $text        The visible text to match against.
 	 * @param boolean $exact_match Search for exact text.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function deselectByText($text, $exact_match = true)
 	{
@@ -168,7 +168,7 @@ class Select extends AbstractTypifiedElement implements ISimpleSetter
 	 *
 	 * @param mixed $value The value to match against.
 	 *
-	 * @return self
+	 * @return static
 	 * @throws SelectException When option with given value can't be found.
 	 */
 	public function selectByValue($value)
@@ -187,7 +187,7 @@ class Select extends AbstractTypifiedElement implements ISimpleSetter
 	 *
 	 * @param mixed $value Value of an option be be deselected.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function deselectByValue($value)
 	{
@@ -201,7 +201,7 @@ class Select extends AbstractTypifiedElement implements ISimpleSetter
 	/**
 	 * Selects all options.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function selectAll()
 	{
@@ -215,7 +215,7 @@ class Select extends AbstractTypifiedElement implements ISimpleSetter
 	 *
 	 * @param array $values Values of options to select.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function setSelected(array $values)
 	{
@@ -236,7 +236,7 @@ class Select extends AbstractTypifiedElement implements ISimpleSetter
 	/**
 	 * Deselects all options.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function deselectAll()
 	{
@@ -254,7 +254,7 @@ class Select extends AbstractTypifiedElement implements ISimpleSetter
 	 *
 	 * @param mixed $value New value.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function setValue($value)
 	{
@@ -271,7 +271,7 @@ class Select extends AbstractTypifiedElement implements ISimpleSetter
 	 * @param array|SelectOption[] $options    Options to be selected.
 	 * @param boolean              $first_only Select only first option.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	protected function selectOptions(array $options, $first_only = false)
 	{

--- a/library/QATools/QATools/HtmlElements/Element/SelectOption.php
+++ b/library/QATools/QATools/HtmlElements/Element/SelectOption.php
@@ -40,7 +40,7 @@ class SelectOption extends AbstractTypifiedElement
 	 *
 	 * @param Select $select Associated SELECT element.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function setSelect(Select $select)
 	{
@@ -54,7 +54,7 @@ class SelectOption extends AbstractTypifiedElement
 	 *
 	 * @param boolean $multiple Append this option to current selection.
 	 *
-	 * @return self
+	 * @return static
 	 * @throws SelectException When no SELECT element association defined.
 	 */
 	public function select($multiple = false)
@@ -76,7 +76,7 @@ class SelectOption extends AbstractTypifiedElement
 	/**
 	 * Deselects option if it is not already deselected.
 	 *
-	 * @return self
+	 * @return static
 	 * @throws SelectException When non-Selenium driver is used.
 	 */
 	public function deselect()
@@ -100,7 +100,7 @@ class SelectOption extends AbstractTypifiedElement
 	 *
 	 * @param boolean|null $select_or_deselect Tells, how option state should be altered.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function toggle($select_or_deselect = null)
 	{

--- a/library/QATools/QATools/HtmlElements/Element/TextInput.php
+++ b/library/QATools/QATools/HtmlElements/Element/TextInput.php
@@ -29,7 +29,7 @@ class TextInput extends AbstractTypifiedElement implements ISimpleSetter
 	/**
 	 * Clears all the text entered into this text input.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function clear()
 	{
@@ -43,7 +43,7 @@ class TextInput extends AbstractTypifiedElement implements ISimpleSetter
 	 *
 	 * @param mixed $keys Text to print.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function sendKeys($keys)
 	{
@@ -67,7 +67,7 @@ class TextInput extends AbstractTypifiedElement implements ISimpleSetter
 	 *
 	 * @param mixed $value New value.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function setValue($value)
 	{

--- a/library/QATools/QATools/HtmlElements/Proxy/TypifiedElementProxy.php
+++ b/library/QATools/QATools/HtmlElements/Proxy/TypifiedElementProxy.php
@@ -98,7 +98,7 @@ class TypifiedElementProxy extends AbstractProxy implements ITypifiedElement
 	 *
 	 * @param string $name Name to set.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function setName($name)
 	{

--- a/library/QATools/QATools/PageObject/Config/Config.php
+++ b/library/QATools/QATools/PageObject/Config/Config.php
@@ -54,7 +54,7 @@ class Config implements IConfig
 	 * @param string $name  Config option name.
 	 * @param mixed  $value Config option value.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function setOption($name, $value)
 	{

--- a/library/QATools/QATools/PageObject/Config/IConfig.php
+++ b/library/QATools/QATools/PageObject/Config/IConfig.php
@@ -25,7 +25,7 @@ interface IConfig
 	 * @param string $name  Config option name.
 	 * @param mixed  $value Config option value.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function setOption($name, $value);
 

--- a/library/QATools/QATools/PageObject/IPageFactory.php
+++ b/library/QATools/QATools/PageObject/IPageFactory.php
@@ -44,7 +44,7 @@ interface IPageFactory
 	 *
 	 * @param Page $page Page to initialize.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function initPage(Page $page);
 
@@ -53,7 +53,7 @@ interface IPageFactory
 	 *
 	 * @param IElementContainer $element_container AbstractElementContainer to be initialized.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function initElementContainer(IElementContainer $element_container);
 
@@ -63,7 +63,7 @@ interface IPageFactory
 	 * @param ISearchContext     $search_context     Context, to be used for element initialization.
 	 * @param IPropertyDecorator $property_decorator Element locator factory.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function initElements(ISearchContext $search_context, IPropertyDecorator $property_decorator);
 

--- a/library/QATools/QATools/PageObject/Page.php
+++ b/library/QATools/QATools/PageObject/Page.php
@@ -112,7 +112,7 @@ abstract class Page implements ISearchContext
 	 *
 	 * @param array $params Page parameters.
 	 *
-	 * @return self
+	 * @return static
 	 * @throws PageException When page url not specified.
 	 */
 	public function open(array $params = array())
@@ -131,7 +131,7 @@ abstract class Page implements ISearchContext
 	 *
 	 * @param IBuilder $url_builder Url builder.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function setUrlBuilder(IBuilder $url_builder)
 	{
@@ -159,7 +159,7 @@ abstract class Page implements ISearchContext
 	 *
 	 * @param string $url URL.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	protected function setBrowserUrl($url)
 	{

--- a/library/QATools/QATools/PageObject/PageFactory.php
+++ b/library/QATools/QATools/PageObject/PageFactory.php
@@ -159,7 +159,7 @@ class PageFactory implements IPageFactory
 	 *
 	 * @param AnnotationManager $manager Annotation manager.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	private function _setAnnotationManager(AnnotationManager $manager)
 	{
@@ -201,7 +201,7 @@ class PageFactory implements IPageFactory
 	 *
 	 * @param Page $page Page to initialize.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function initPage(Page $page)
 	{
@@ -239,7 +239,7 @@ class PageFactory implements IPageFactory
 	 *
 	 * @param IElementContainer $element_container AbstractElementContainer to be initialized.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function initElementContainer(IElementContainer $element_container)
 	{
@@ -252,7 +252,7 @@ class PageFactory implements IPageFactory
 	 * @param ISearchContext     $search_context     Context, to be used for element initialization.
 	 * @param IPropertyDecorator $property_decorator Element locator factory.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function initElements(ISearchContext $search_context, IPropertyDecorator $property_decorator)
 	{
@@ -265,7 +265,7 @@ class PageFactory implements IPageFactory
 	 * @param ISearchContext     $search_context     Search context.
 	 * @param IPropertyDecorator $property_decorator Property decorator.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	protected function proxyFields(ISearchContext $search_context, IPropertyDecorator $property_decorator)
 	{

--- a/library/QATools/QATools/PageObject/PageUrlMatcher/PageUrlMatcherRegistry.php
+++ b/library/QATools/QATools/PageObject/PageUrlMatcher/PageUrlMatcherRegistry.php
@@ -53,7 +53,7 @@ class PageUrlMatcherRegistry
 	 *
 	 * @param IPageUrlMatcher $page_url_matcher Page url matcher.
 	 *
-	 * @return self
+	 * @return static
 	 * @throws PageUrlMatcherException When page url matcher with same priority is already registered.
 	 */
 	public function add(IPageUrlMatcher $page_url_matcher)

--- a/library/QATools/QATools/PageObject/Proxy/AbstractProxy.php
+++ b/library/QATools/QATools/PageObject/Proxy/AbstractProxy.php
@@ -82,7 +82,7 @@ abstract class AbstractProxy extends AbstractElementCollection implements IProxy
 	 *
 	 * @param string $class_name Class name to proxy.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function setClassName($class_name)
 	{

--- a/library/QATools/QATools/PageObject/Proxy/IProxy.php
+++ b/library/QATools/QATools/PageObject/Proxy/IProxy.php
@@ -27,7 +27,7 @@ interface IProxy
 	 *
 	 * @param string $class_name Class name to proxy.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function setClassName($class_name);
 

--- a/library/QATools/QATools/PageObject/Url/Parser.php
+++ b/library/QATools/QATools/PageObject/Url/Parser.php
@@ -91,7 +91,7 @@ class Parser
 	 *
 	 * @param array $params GET params.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function setParams(array $params)
 	{
@@ -105,7 +105,7 @@ class Parser
 	 *
 	 * @param Parser $parser The url parser to merge.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function merge(Parser $parser)
 	{


### PR DESCRIPTION
Using `static` instead of `self` in a DocBlocks of methods using fluid interface improves IDE auto-complete when overriding such methods (e.g. typified element).